### PR TITLE
Allow prediction in memory, time process

### DIFF
--- a/scripts/prediction/run_prediction_distance_unet.py
+++ b/scripts/prediction/run_prediction_distance_unet.py
@@ -5,7 +5,11 @@ Functions for the parallelization end with '_slurm' and divide the process into 
 prediction, and segmentation.
 """
 import argparse
+import json
+import time
+import os
 
+import imageio.v3 as imageio
 import torch
 import z5py
 
@@ -19,7 +23,12 @@ def main():
     parser.add_argument("-m", "--model", required=True)
     parser.add_argument("-k", "--input_key", default=None)
     parser.add_argument("-s", "--scale", default=None, type=float, help="Downscale the image by the given factor.")
-    parser.add_argument("-b", "--block_shape", default=None, type=int, nargs=3)
+    parser.add_argument("-b", "--block_shape", default=None, type=str)
+    parser.add_argument("--halo", default=None, type=str)
+    parser.add_argument("--memory", action="store_true", help="Perform prediction in memory and save output as tif.")
+    parser.add_argument("--time", action="store_true", help="Time prediction process.")
+    parser.add_argument("--seg_class", default=None, type=str,
+                        help="Segmentation class to load parameters for masking input.")
 
     args = parser.parse_args()
 
@@ -36,21 +45,51 @@ def main():
         if args.block_shape is None:
             block_shape = (64, 256, 256) if have_cuda else (64, 64, 64)
         else:
-            block_shape = tuple(args.block_shape)
-        halo = (16, 64, 64) if have_cuda else (8, 32, 32)
+            block_shape = tuple(json.loads(args.block_shape))
+
     else:
         if args.block_shape is None:
             chunks = z5py.File(args.input, "r")[args.input_key].chunks
             block_shape = tuple([2 * ch for ch in chunks]) if have_cuda else tuple(chunks)
         else:
-            block_shape = tuple(args.block_shape)
-        halo = (16, 64, 64) if have_cuda else (8, 32, 32)
+            block_shape = json.loads(args.block_shape)
 
-    run_unet_prediction(
-        args.input, args.input_key, args.output_folder, args.model,
-        scale=scale, min_size=min_size,
-        block_shape=block_shape, halo=halo,
-    )
+    if args.halo is None:
+        halo = (16, 64, 64) if have_cuda else (8, 32, 32)
+    else:
+        halo = tuple(json.loads(args.halo))
+
+    if args.time:
+        start = time.perf_counter()
+
+    if args.memory:
+        segmentation = run_unet_prediction(
+            args.input, args.input_key, output_folder=None, model_path=args.model,
+            scale=scale, min_size=min_size,
+            block_shape=block_shape, halo=halo,
+            seg_class=args.seg_class,
+        )
+
+        abs_path = os.path.abspath(args.input)
+        basename = ".".join(os.path.basename(abs_path).split(".")[:-1])
+        output_path = os.path.join(args.output_folder, basename + "_seg.tif")
+        imageio.imwrite(output_path, segmentation, compression="zlib")
+        timer_output = os.path.join(args.output_folder, basename + "_timer.json")
+
+    else:
+        run_unet_prediction(
+            args.input, args.input_key, output_folder=args.output_folder, model_path=args.model,
+            scale=scale, min_size=min_size,
+            block_shape=block_shape, halo=halo,
+            seg_class=args.seg_class,
+        )
+        timer_output = os.path.join(args.output_folder, "timer.json")
+
+    if args.time:
+        duration = time.perf_counter() - start
+        time_dict = {"total_duration[s]": duration}
+        with open(timer_output, "w") as f:
+            json.dump(time_dict, f, indent='\t', separators=(',', ': '))
 
 
 if __name__ == "__main__":

--- a/scripts/prediction/run_prediction_distance_unet.py
+++ b/scripts/prediction/run_prediction_distance_unet.py
@@ -29,6 +29,14 @@ def main():
     parser.add_argument("--time", action="store_true", help="Time prediction process.")
     parser.add_argument("--seg_class", default=None, type=str,
                         help="Segmentation class to load parameters for masking input.")
+    parser.add_argument("--center_distance_threshold", default=0.4, type=float,
+                        help="The threshold applied to the distance center predictions to derive seeds.")
+    parser.add_argument("--boundary_distance_threshold", default=None, type=float,
+                        help="The threshold applied to the boundary predictions to derive seeds. \
+                        By default this is set to 'None', \
+                        in which case the boundary distances are not used for the seeds.")
+    parser.add_argument("--fg_threshold", default=0.5, type=float,
+                        help="The threshold applied to the foreground prediction for deriving the watershed mask.")
 
     args = parser.parse_args()
 
@@ -68,6 +76,9 @@ def main():
             scale=scale, min_size=min_size,
             block_shape=block_shape, halo=halo,
             seg_class=args.seg_class,
+            center_distance_threshold = args.center_distance_threshold,
+            boundary_distance_threshold = args.boundary_distance_threshold,
+            fg_threshold = args.fg_threshold,
         )
 
         abs_path = os.path.abspath(args.input)
@@ -82,6 +93,9 @@ def main():
             scale=scale, min_size=min_size,
             block_shape=block_shape, halo=halo,
             seg_class=args.seg_class,
+            center_distance_threshold = args.center_distance_threshold,
+            boundary_distance_threshold = args.boundary_distance_threshold,
+            fg_threshold = args.fg_threshold,
         )
         timer_output = os.path.join(args.output_folder, "timer.json")
 


### PR DESCRIPTION
The project aims to time the process of prediction and segmentation.
To avoid overhead, it allows the prediction to run within memory without saving intermediate results like masks, or intermediate prediction channels.

WIP

I changed the input method for the block shape from `nargs=3` to `json.loads` to be more consistent with other scripts.