### PR TITLE
Update environment.yaml

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,11 +1,9 @@
 name: flamingo
 
 channels:
-  - pytorch
   - conda-forge
 
 dependencies:
-  - cpuonly
   - cluster_tools
   - scikit-image
   - pybdv


### PR DESCRIPTION
This PR updates the `environment.yaml` file to install `pytorch` from `conda-forge`.

Was there a reason to use it from `pytorch` channel? Any limitations for using `pytorch<2.5` and/or `cpuonly`?

If not, I suggest using the one from `conda-forge`!