### PR TITLE
Export central path of tonotopic mapping

### DIFF
--- a/flamingo_tools/analysis/central_path_utils.py
+++ b/flamingo_tools/analysis/central_path_utils.py
@@ -1,0 +1,164 @@
+import math
+from typing import List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from flamingo_tools.s3_utils import get_s3_path
+
+
+def insert_coordinate(
+    df: pd.DataFrame,
+    optimal_pos: int,
+    new_point: Tuple[int],
+) -> pd.DataFrame:
+    print(f"Inserting {new_point} at {optimal_pos}.")
+    # start of DataFrame
+    if optimal_pos == 0:
+        entry_dic = {
+            "spot_id": len(df),
+            "x": new_point[0],
+            "y": new_point[1],
+            "z": new_point[2],
+        }
+        insert_df = pd.DataFrame([entry_dic])
+        result = pd.concat([
+            insert_df,
+            df.iloc[:]
+        ], ignore_index=True)
+    # end of DataFrame
+    elif optimal_pos == len(df):
+        insert_df = pd.DataFrame([entry_dic])
+        result = pd.concat([
+            df.iloc[:],
+            insert_df
+        ], ignore_index=True)
+
+    else:
+        # Insert the point at the optimal position
+        coord_columns = ["x", "y", "z"]
+
+        extrapolate_columns = [c for c in list(df.columns)[1:] if c not in coord_columns]
+        entry_dic = {
+            "spot_id": len(df),
+            "x": new_point[0],
+            "y": new_point[1],
+            "z": new_point[2],
+        }
+        coord_before = [df.iloc[optimal_pos - 1]["x"], df.iloc[optimal_pos - 1]["y"], df.iloc[optimal_pos - 1]["z"]]
+        coord_after = [df.iloc[optimal_pos + 1]["x"], df.iloc[optimal_pos + 1]["y"], df.iloc[optimal_pos + 1]["z"]]
+        dist_before = math.dist(new_point, coord_before)
+        dist_after = math.dist(new_point, coord_after)
+        factor_before = dist_before / (dist_before + dist_after)
+        factor_after = dist_after / (dist_before + dist_after)
+        print(factor_before, factor_after)
+        for col in extrapolate_columns:
+            value_before = df.iloc[optimal_pos - 1][col]
+            value_after = df.iloc[optimal_pos + 1][col]
+            entry_dic[col] = factor_before * value_before + factor_after * value_after
+
+        insert_df = pd.DataFrame([entry_dic])
+        print(insert_df)
+
+        result = pd.concat([
+            df.iloc[:optimal_pos],
+            insert_df,
+            df.iloc[optimal_pos:]
+        ], ignore_index=True)
+
+    return result
+
+
+def find_optimal_point_for_insert(
+    df: pd.DataFrame,
+    new_point: Tuple[int],
+    tolerance: str = 1e-10,
+) -> Tuple[int]:
+    """Insert a single point into the path to minimize total path length.
+
+    Args:
+        df: pandas DataFrame with 'x' and 'y' columns (ordered path)
+        new_point: tuple or array-like (x, y) of the point to insert
+
+    Returns:
+        Optimal position for point insertion
+    """
+    # Convert new point to numpy array
+    new_point = np.array(new_point)
+    coord_columns = ["x", "y", "z"]
+    # Check if point already exists in the dataframe (with tolerance)
+    # Check for existing point using numeric columns only
+    df_numeric = df[coord_columns]
+    distances = np.sqrt(((df_numeric.values - new_point) ** 2).sum(axis=1))
+    if (distances < tolerance).any():
+        print(f"Point {new_point} already exists in the path. Skipping insertion.")
+        return None
+
+    # Calculate distances between consecutive points in the original path
+    coords = df[coord_columns].values
+    n = len(coords)
+
+    # If path has only one point, insert after it
+    if n == 1:
+        return 1
+
+    # Calculate the cost of inserting at each position
+    # Cost = distance from previous point to new point + distance from new point to next point
+    # minus the original distance between previous and next point
+    costs = []
+    for i in range(n + 1):
+        if i == 0:
+            # Insert at beginning
+            cost = math.dist(new_point, coords[0])
+        elif i == n:
+            # Insert at end
+            cost = math.dist(new_point, coords[n - 1])
+        else:
+            # Insert between i and i+1
+            cost = (math.dist(coords[i - 1], new_point) +
+                    math.dist(new_point, coords[i]) -
+                    math.dist(coords[i - 1], coords[i]))
+
+        costs.append(cost)
+
+    # Find the position with minimum cost (most reduction in total length)
+    optimal_pos = np.argmin(costs)
+    print(optimal_pos)
+
+    return int(optimal_pos)
+
+
+def insert_coordinates_to_central_path(
+    table_path: str,
+    output_path: str,
+    coordinates: List[List[int]],
+    s3: bool = False,
+    s3_credentials: Optional[str] = None,
+    s3_bucket_name: Optional[str] = None,
+    s3_service_endpoint: Optional[str] = None,
+):
+    """Insert coordinates into a central path of an SGN or IHC segmentation.
+
+    Args:
+        table_path: Path to table featuring central path as spots.
+        output_path: Output path.
+        coordinates: List of a single or multiple coordinates to insert into the path.
+        s3: Use S3 bucket.
+        s3_credentials:
+        s3_bucket_name:
+        s3_service_endpoint:
+    """
+    if s3:
+        tsv_path, fs = get_s3_path(table_path, bucket_name=s3_bucket_name,
+                                   service_endpoint=s3_service_endpoint, credential_file=s3_credentials)
+        with fs.open(tsv_path, "r") as f:
+            table = pd.read_csv(f, sep="\t")
+    else:
+        table = pd.read_csv(table_path, sep="\t")
+
+    for coord in coordinates:
+        optimal_pos = find_optimal_point_for_insert(table, coord)
+        if optimal_pos is not None:
+            table = insert_coordinate(table, optimal_pos, coord)
+
+    table.to_csv(output_path, sep="\t", index=False)

--- a/flamingo_tools/postprocessing/cli.py
+++ b/flamingo_tools/postprocessing/cli.py
@@ -308,6 +308,8 @@ def tonotopic_mapping():
         "-c", "--components", type=int, nargs="+", default=[1],
         help="List of connected components. The order has to match the order within the cochlear volume.",
     )
+    parser.add_argument("--include_gap", action="store_true",
+                        help="Include gaps between components for calculating the length of the central path.")
 
     # options for S3 bucket
     parser.add_argument("--s3", action="store_true", help="Flag for using S3 bucket.")
@@ -332,6 +334,7 @@ def tonotopic_mapping():
         apex_position=args.apex_position,
         cell_type=args.cell_type,
         component_list=args.components,
+        include_gap=args.include_gap,
         s3=args.s3,
         s3_credentials=args.s3_credentials,
         s3_bucket_name=args.s3_bucket_name,

--- a/flamingo_tools/postprocessing/cli.py
+++ b/flamingo_tools/postprocessing/cli.py
@@ -3,7 +3,7 @@
 import argparse
 
 from .label_components import label_components_single
-from .cochlea_mapping import tonotopic_mapping_single, equidistant_centers_single
+from .cochlea_mapping import tonotopic_mapping_json_wrapper, equidistant_centers_single
 from flamingo_tools.json_util import export_dictionary_as_json
 from flamingo_tools.measurements import object_measures_json_wrapper
 from flamingo_tools.extract_block_util import extract_block_json_wrapper, extract_central_block_from_json
@@ -285,12 +285,16 @@ def tonotopic_mapping():
     parser = argparse.ArgumentParser(
         description="Script to extract region of interest (ROI) block around center coordinate.")
 
-    parser.add_argument("-i", "--input", type=str, required=True, help="Input path to segmentation table.")
+    parser.add_argument("-i", "--input", type=str, default=None, help="Input path to segmentation table.")
     parser.add_argument("-o", "--output", type=str, default=None,
                         help="Output path for segmentation table. Default: Overwrite input table.")
     parser.add_argument("-f", "--force", action="store_true", help="Forcefully overwrite output.")
 
     # options for tonotopic mapping
+    parser.add_argument("--json_info", type=str, default=None,
+                        help="JSON file with dataset information.")
+    parser.add_argument("--central_spots_path", type=str, default=None,
+                        help="Dataframe containing spots of the central path of the segmentation.")
     parser.add_argument("--animal", type=str, default="mouse",
                         help="Animal type to be used for frequency mapping. Either 'mouse' or 'gerbil'.")
     parser.add_argument("--otof", action="store_true", help="Use frequency mapping for OTOF cochleae.")
@@ -317,9 +321,11 @@ def tonotopic_mapping():
 
     args = parser.parse_args()
 
-    tonotopic_mapping_single(
+    tonotopic_mapping_json_wrapper(
         table_path=args.input,
         out_path=args.output,
+        json_file=args.json_info,
+        central_spots_path=args.central_spots_path,
         force_overwrite=args.force,
         animal=args.animal,
         otof=args.otof,

--- a/flamingo_tools/postprocessing/cochlea_mapping.py
+++ b/flamingo_tools/postprocessing/cochlea_mapping.py
@@ -174,6 +174,7 @@ def measure_run_length_sgns(
         centroids_components: List[np.ndarray],
         scale_factor: int = 10,
         apex_higher: bool = True,
+        include_gap: bool = False,
 ) -> Tuple[float, np.ndarray, dict]:
     """Measure the run lengths of the SGN segmentation by finding a central path through Rosenthal's canal.
     This function handles cases with a single or multiple components.
@@ -196,6 +197,7 @@ def measure_run_length_sgns(
         centroids_components: List of centroids of the SGN segmentation, ndarray of shape (N, 3).
         scale_factor: Downscaling factor for finding the central path.
         apex_higher: Flag for identifying apex and base. Apex is set to node with higher y-value if True.
+        include_gap: Include the distance between different components for calculating the run length.
 
     Returns:
         Total distance of the path.
@@ -273,14 +275,20 @@ def measure_run_length_sgns(
         total_path = [np.flip(t) for t in total_path]
 
     # 4) Assign distance of nodes by skipping intermediate space between separate components
+    if include_gap:
+        # flatten the list of components
+        total_path = [[node for comp_path in total_path for node in comp_path]]
     total_distance = sum([math.dist(p[num + 1], p[num]) for p in total_path for num in range(len(p) - 1)])
-    print("total dist", total_distance)
+    print(f"The total path has length {round(total_distance)} µm. Gaps between components included: {include_gap}.")
+
     path_dict = {}
     accumulated = 0
     index = 0
     for num, pa in enumerate(total_path):
+        # first node of first path segment
         if num == 0:
             path_dict[0] = {"pos": total_path[0][0], "length_fraction": 0}
+        # first node of other path segments
         else:
             path_dict[index] = {"pos": total_path[num][0], "length_fraction": path_dict[index - 1]["length_fraction"]}
 
@@ -291,6 +299,7 @@ def measure_run_length_sgns(
             rel_dist = accumulated / total_distance
             path_dict[index] = {"pos": p, "length_fraction": rel_dist}
             index += 1
+    # add last node of last path segment
     path_dict[index - 1] = {"pos": total_path[-1][-1, :], "length_fraction": 1}
 
     # 5) Concatenate individual paths to form total path
@@ -331,6 +340,7 @@ def measure_run_length_ihcs(
     max_edge_distance: float = 30,
     apex_higher: bool = True,
     component_label: List[int] = [1],
+    include_gap: bool = False,
 ) -> Tuple[float, np.ndarray, dict]:
     """Measure the run lengths of the IHC segmentation
     by determining the shortest path between the most distant nodes of a graph.
@@ -345,6 +355,7 @@ def measure_run_length_ihcs(
         max_edge_distance: Maximal edge distance between graph nodes to create an edge between nodes.
         apex_higher: Flag for identifying apex and base. Apex is set to node with higher y-value if True.
         component_label: List of component labels. Determines the order of components to connect.
+        include_gap: Include the distance between different components for calculating the run length.
 
     Returns:
         Total distance of the path.
@@ -426,6 +437,14 @@ def measure_run_length_ihcs(
     path = nx.shortest_path(graph, source=apex_node, target=base_node)
     total_distance = nx.path_weight(graph, path, weight="weight")
     path_pos = [graph.nodes[p]["pos"] for p in path]
+    if not include_gap:
+        # remove distances between components which are larger than the max edge distance
+        total_distance = sum([math.dist(path_pos[num], path_pos[num + 1]) for num in range(len(path_pos) - 1) if
+                              math.dist(path_pos[num], path_pos[num + 1]) <= max_edge_distance])
+    else:
+        total_distance = sum([math.dist(path_pos[num], path_pos[num + 1]) for num in range(len(path_pos) - 1)])
+
+    print(f"The total path has length {round(total_distance)} µm. Gaps between components included: {include_gap}.")
     path = moving_average_3d(path_pos, window=3)
 
     # assign relative distance to points on path
@@ -434,7 +453,8 @@ def measure_run_length_ihcs(
     accumulated = 0
     for num, p in enumerate(path_pos[1:-1]):
         distance = math.dist(path_pos[num], p)
-        accumulated += distance
+        if include_gap or distance <= max_edge_distance:
+            accumulated += distance
         rel_dist = accumulated / total_distance
         path_dict[num + 1] = {"pos": p, "length_fraction": rel_dist}
     path_dict[len(path_pos)] = {"pos": path_pos[-1], "length_fraction": 1}
@@ -630,21 +650,10 @@ def equidistant_centers(
     centroids = list(zip(new_subset["anchor_x"], new_subset["anchor_y"], new_subset["anchor_z"]))
 
     if cell_type == "ihc":
-        if len(component_label) != 1:
-            total_distance, path, _ = measure_run_length_ihcs(
-                centroids, component_label=component_label,
-            )
-            return get_centers_from_path(path, total_distance, n_blocks=n_blocks, offset_blocks=offset_blocks)
-        else:
-            centroids_components = []
-            for label in component_label:
-                subset = table[table["component_labels"] == label]
-                subset_centroids = list(zip(subset["anchor_x"], subset["anchor_y"], subset["anchor_z"]))
-                centroids_components.append(subset_centroids)
-            total_distance, path, path_dict = measure_run_length_ihcs(
-                centroids_components,
-            )
-            return get_centers_from_path_dict(path_dict, n_blocks=n_blocks, offset_blocks=offset_blocks)
+        total_distance, path, path_dict = measure_run_length_ihcs(
+            centroids, component_label=component_label, include_gap=True,
+        )
+        return get_centers_from_path_dict(path_dict, total_distance, n_blocks=n_blocks, offset_blocks=offset_blocks)
 
     else:
         centroids_components = []
@@ -652,7 +661,7 @@ def equidistant_centers(
             subset = table[table["component_labels"] == label]
             subset_centroids = list(zip(subset["anchor_x"], subset["anchor_y"], subset["anchor_z"]))
             centroids_components.append(subset_centroids)
-        total_distance, path, path_dict = measure_run_length_sgns(centroids_components)
+        total_distance, path, path_dict = measure_run_length_sgns(centroids_components, include_gap=True)
         if len(component_label) == 1:
             return get_centers_from_path(path, total_distance, n_blocks=n_blocks, offset_blocks=offset_blocks)
         else:
@@ -668,6 +677,7 @@ def tonotopic_mapping(
     apex_higher: bool = True,
     otof: bool = False,
     central_path_df: Optional[pd.DataFrame] = None,
+    include_gap: bool = False,
 ) -> pd.DataFrame:
     """Tonotopic mapping of SGNs or IHCs by supplying a table with component labels.
     The mapping assigns a tonotopic label to each instance according to the position along the length of the cochlea.
@@ -681,6 +691,7 @@ def tonotopic_mapping(
         apex_higher: Flag for identifying apex and base. Apex is set to node with higher y-value if True.
         otof: Use mapping by *Mueller, Hearing Research 202 (2005) 63-73* for OTOF cochleae.
         central_path_df: Dataframe featuring the spots for the central path through the segmentation.
+        include_gap: Include the distance between different components for calculating the run length.
 
     Returns:
         Table with tonotopic label for cells.
@@ -704,6 +715,7 @@ def tonotopic_mapping(
 
             total_distance, _, path_dict = measure_run_length_ihcs(
                 centroids, centroids_components, component_label=component_label, apex_higher=apex_higher,
+                include_gap=include_gap,
             )
 
         elif cell_type in ["sgn", "SGN"]:
@@ -714,6 +726,7 @@ def tonotopic_mapping(
                 centroids_components.append(subset_centroids)
             total_distance, _, path_dict = measure_run_length_sgns(
                 centroids_components, apex_higher=apex_higher,
+                include_gap=include_gap,
             )
 
         else:
@@ -766,6 +779,7 @@ def tonotopic_mapping_single(
     component_list: List[int] = [1],
     component_mapping: Optional[List[int]] = None,
     central_spots_path: Optional[str] = None,
+    include_gap: bool = False,
     s3: bool = False,
     s3_credentials: Optional[str] = None,
     s3_bucket_name: Optional[str] = None,
@@ -792,6 +806,7 @@ def tonotopic_mapping_single(
         component_list: List of components. Can be passed to obtain the number of instances within the component list.
         component_mapping: Components to use for tonotopic mapping. Ignore components torn parallel to main canal.
         central_spots_path: Provide table featuring spots for central path through segmentation for tonotopic mapping.
+        include_gap: Include the distance between different components for calculating the run length.
         s3: Use S3 bucket.
         s3_credentials:
         s3_bucket_name:
@@ -834,6 +849,7 @@ def tonotopic_mapping_single(
                                                    cell_type=cell_type, component_mapping=component_mapping,
                                                    apex_higher=apex_higher,
                                                    central_path_df=central_path_df,
+                                                   include_gap=include_gap,
                                                    otof=otof)
 
         table.to_csv(out_path, sep="\t", index=False)

--- a/flamingo_tools/postprocessing/cochlea_mapping.py
+++ b/flamingo_tools/postprocessing/cochlea_mapping.py
@@ -112,7 +112,7 @@ def central_path_edt_graph(
     return np.array(coords)
 
 
-def moving_average_3d(path: np.ndarray, window: int = 5) -> np.ndarray:
+def moving_average_3d(path: np.ndarray, window: int = 3) -> np.ndarray:
     """Smooth a 3D path with a simple moving average filter.
 
     Args:
@@ -134,13 +134,47 @@ def moving_average_3d(path: np.ndarray, window: int = 5) -> np.ndarray:
     return smooth_path
 
 
-def measure_run_length_sgns_multi_component(
+def extend_path(
+    path_pos,
+    extension_length: Optional[float] = None,
+    max_edge_distance: float = 30,
+):
+    """Extend path of nodes by adding additional points inbetween.
+    Additional nodes are added linearly between existing ones in regular intervals.
+    The interval can be specified using the extension length.
+
+    Args:
+        path_pos: List of coordinates in 3D space.
+        extension_length: Length for the extension between existing nodes
+        max_edge_distance: Maximal distance between two nodes which are viable for extension.
+
+    Returns:
+        Extended coordinates
+    """
+    if extension_length is not None:
+        print(f"Extending nodes every {extension_length}µm.")
+        path_extended = []
+        for num in range(len(path_pos) - 1):
+            dist = math.dist(path_pos[num], path_pos[num + 1])
+            # section between two components
+            if dist > max_edge_distance:
+                path_extended.append(path_pos[num])
+                continue
+            extended_space = np.linspace(path_pos[num], path_pos[num + 1], round(dist / extension_length))
+            path_extended.extend(extended_space[:-1])
+        path_extended.append(path_pos[-1])
+        return np.array(path_extended)
+    else:
+        return np.array(path_pos)
+
+
+def measure_run_length_sgns(
         centroids_components: List[np.ndarray],
         scale_factor: int = 10,
         apex_higher: bool = True,
 ) -> Tuple[float, np.ndarray, dict]:
     """Measure the run lengths of the SGN segmentation by finding a central path through Rosenthal's canal.
-    This function handles the case were the cochlea has been torn into multiple components.
+    This function handles cases with a single or multiple components.
     The List of centroids has to be in order of neighboring components.
     For each component:
     1) Process centroids of each component:
@@ -167,7 +201,7 @@ def measure_run_length_sgns_multi_component(
         A dictionary containing the position and the length fraction of each point in the path.
     """
     total_path = []
-    print(f"Evaluating {len(centroids_components)} components.")
+    print(f"Evaluating {len(centroids_components)} component(s).")
 
     def _find_central_path_through_downscaled_mask(centroids, downscaling_factor):
         # Check for the existence of and the shortest path between the most distant nodes in the downscaled volume.
@@ -202,28 +236,29 @@ def measure_run_length_sgns_multi_component(
             path = _find_central_path_through_downscaled_mask(centroids, downscaling_factor=scale_factor)
 
         path = path * scale_factor
-        path = moving_average_3d(path, window=5)
+        path = moving_average_3d(path, window=3)
         total_path.append(path)
 
     # 2) Order paths to have consistent start/end points
-    # Find starting order of first two components
-    c1a = total_path[0][0, :]
-    c1b = total_path[0][-1, :]
+    if len(total_path) > 1:
+        # Find starting order of first two components
+        c1a = total_path[0][0, :]
+        c1b = total_path[0][-1, :]
 
-    c2a = total_path[1][0, :]
-    c2b = total_path[1][-1, :]
+        c2a = total_path[1][0, :]
+        c2b = total_path[1][-1, :]
 
-    distances = [math.dist(c1a, c2a), math.dist(c1a, c2b), math.dist(c1b, c2a), math.dist(c1b, c2b)]
-    min_index = distances.index(min(distances))
-    if min_index in [0, 1]:
-        total_path[0] = np.flip(total_path[0], axis=0)
+        distances = [math.dist(c1a, c2a), math.dist(c1a, c2b), math.dist(c1b, c2a), math.dist(c1b, c2b)]
+        min_index = distances.index(min(distances))
+        if min_index in [0, 1]:
+            total_path[0] = np.flip(total_path[0], axis=0)
 
-    # Order other components from start to end
-    for num in range(0, len(total_path) - 1):
-        dist_connecting_nodes_1 = math.dist(total_path[num][-1, :], total_path[num + 1][0, :])
-        dist_connecting_nodes_2 = math.dist(total_path[num][-1, :], total_path[num + 1][-1, :])
-        if dist_connecting_nodes_2 < dist_connecting_nodes_1:
-            total_path[num + 1] = np.flip(total_path[num + 1], axis=0)
+        # Order other components from start to end
+        for num in range(0, len(total_path) - 1):
+            dist_connecting_nodes_1 = math.dist(total_path[num][-1, :], total_path[num + 1][0, :])
+            dist_connecting_nodes_2 = math.dist(total_path[num][-1, :], total_path[num + 1][-1, :])
+            if dist_connecting_nodes_2 < dist_connecting_nodes_1:
+                total_path[num + 1] = np.flip(total_path[num + 1], axis=0)
 
     # 3) Assign base/apex position to path
     # compare y-value to not get into confusion with MoBIE dimensions
@@ -237,6 +272,7 @@ def measure_run_length_sgns_multi_component(
 
     # 4) Assign distance of nodes by skipping intermediate space between separate components
     total_distance = sum([math.dist(p[num + 1], p[num]) for p in total_path for num in range(len(p) - 1)])
+    print("total dist", total_distance)
     path_dict = {}
     accumulated = 0
     index = 0
@@ -259,268 +295,6 @@ def measure_run_length_sgns_multi_component(
     path = np.concatenate(total_path, axis=0)
 
     return total_distance, path, path_dict
-
-
-def measure_run_length_sgns(
-        centroids: np.ndarray,
-        scale_factor: int = 10,
-        apex_higher: bool = True,
-        extension_length: Optional[float] = None,
-) -> Tuple[float, np.ndarray, dict]:
-    """Measure the run lengths of the SGN segmentation by finding a central path through Rosenthal's canal.
-    1) Create a binary mask based on down-scaled centroids.
-    2) Dilate the mask and close holes to ensure a filled structure.
-    3) Determine the endpoints of the structure using the principal axis.
-    4) Assign base/apex position to path.
-    5) Identify a central path based on the 3D Euclidean distance transform.
-    6) The path is up-scaled and smoothed using a moving average filter.
-    7) The points of the path are fed into a dictionary along with the fractional length.
-
-    Args:
-        centroids: Centroids of the SGN segmentation, ndarray of shape (N, 3).
-        scale_factor: Downscaling factor for finding the central path.
-        apex_higher: Flag for identifying apex and base. Apex is set to node with higher y-value if True.
-        extension_length: Extend central path between segmentation instances. Adds nodes in regular interval [µm].
-
-    Returns:
-        Total distance of the path.
-        Path as an nd.array of positions.
-        A dictionary containing the position and the length fraction of each point in the path.
-    """
-    # 1) Create a binary mask based on down-scaled centroids.
-    mask = downscaled_centroids(centroids, scale_factor=scale_factor, downsample_mode="capped")
-    # 2) Dilate the mask and close holes to ensure a filled structure.
-    mask = binary_dilation(mask, np.ones((3, 3, 3)), iterations=1)
-    mask = binary_closing(mask, np.ones((3, 3, 3)), iterations=1)
-    pts = np.argwhere(mask == 1)
-
-    # 3) Find two endpoints: min/max along principal axis.
-    c_mean = pts.mean(axis=0)
-    cov = np.cov((pts - c_mean).T)
-    evals, evecs = np.linalg.eigh(cov)
-    axis = evecs[:, np.argmax(evals)]
-    proj = (pts - c_mean) @ axis
-    start_voxel = tuple(pts[proj.argmin()])
-    end_voxel = tuple(pts[proj.argmax()])
-
-    # 4) Assign base/apex position to path.
-    # compare y-value to not get into confusion with MoBIE dimensions
-    if start_voxel[1] > end_voxel[1]:
-        apex = start_voxel if apex_higher else end_voxel
-        base = end_voxel if apex_higher else start_voxel
-    else:
-        apex = end_voxel if apex_higher else start_voxel
-        base = start_voxel if apex_higher else end_voxel
-
-    # 5) Identify a central path based on the 3D Euclidean distance transform.
-    path = central_path_edt_graph(mask, apex, base)
-    # 6) The path is up-scaled and smoothed using a moving average filter.
-    path_pos = path * scale_factor
-
-    if extension_length is not None:
-        path_extended = []
-        for num in range(len(path_pos) - 1):
-            dist = math.dist(path_pos[num], path_pos[num + 1])
-            extended_space = np.linspace(path_pos[num], path_pos[num + 1], round(dist))
-            path_extended.append(path_pos[num])
-            path_extended.extend(extended_space)
-        path_extended.append(path_pos[-1])
-        path = moving_average_3d(np.array(path_extended), window=3)
-    else:
-        path = moving_average_3d(path_pos, window=5)
-
-    total_distance = sum([math.dist(path[num + 1], path[num]) for num in range(len(path) - 1)])
-
-    # 7) The points of the path are fed into a dictionary along with the fractional length.
-    path_dict = {}
-    path_dict[0] = {"pos": path[0], "length_fraction": 0}
-    accumulated = 0
-    for num, p in enumerate(path[1:-1]):
-        distance = math.dist(path[num], p)
-        accumulated += distance
-        rel_dist = accumulated / total_distance
-        path_dict[num + 1] = {"pos": p, "length_fraction": rel_dist}
-    path_dict[len(path)] = {"pos": path[-1], "length_fraction": 1}
-
-    return total_distance, path, path_dict
-
-
-def measure_run_length_ihcs_multi_component(
-    centroids_components: List[np.ndarray],
-    max_edge_distance: float = 30,
-    apex_higher: bool = True,
-    component_label: List[int] = [1],
-    extension_length: Optional[float] = None,
-) -> Tuple[float, np.ndarray, dict]:
-    """Adaptation of measure_run_length_sgns_multi_component to IHCs.
-
-    """
-    total_path = []
-    print(f"Evaluating {len(centroids_components)} components.")
-    # 1) Process centroids for each component
-    for centroids in centroids_components:
-        max_edge_dist_tmp = max([round(find_max_min_distance(centroids) + 0.5), max_edge_distance])
-        graph = nx.Graph()
-        coords = {}
-        labels = [int(i) for i in range(len(centroids))]
-        for index, element in zip(labels, centroids):
-            coords[index] = element
-
-        for num, pos in coords.items():
-            graph.add_node(num, pos=pos)
-
-        # create edges between points whose distance is less than threshold max_edge_distance
-        for num_i, pos_i in coords.items():
-            for num_j, pos_j in coords.items():
-                if num_i < num_j:
-                    dist = math.dist(pos_i, pos_j)
-                    if dist <= max_edge_dist_tmp:
-                        graph.add_edge(num_i, num_j, weight=dist)
-
-        components = [list(c) for c in nx.connected_components(graph)]
-        len_c = [len(c) for c in components]
-        len_c, components = zip(*sorted(zip(len_c, components), reverse=True))
-
-        # combine separate connected components by adding edges between nodes which are closest together
-        if len(components) > 1:
-            print(f"Graph consists of {len(components)} connected components.")
-            if len(component_label) != len(components):
-                raise ValueError(f"Length of graph components {len(components)} "
-                                 f"does not match number of component labels {len(component_label)}.")
-
-            # Order connected components in order of component labels
-            # e.g. component_labels = [7, 4, 1, 11] and len_c = [600, 400, 300, 55]
-            # get re-ordered to [300, 400, 600, 55]
-            components_sorted = [
-                c[1] for _, c in sorted(zip(sorted(range(len(component_label)), key=lambda i: component_label[i]),
-                                            sorted(zip(len_c, components), key=lambda x: x[0], reverse=True)))]
-
-            # Connect nodes of neighboring components that are closest together
-            for num in range(0, len(components_sorted) - 1):
-                min_dist = float("inf")
-                closest_pair = None
-
-                # Compare only nodes between two neighboring components
-                for node_a in components_sorted[num]:
-                    for node_b in components_sorted[num + 1]:
-                        dist = math.dist(graph.nodes[node_a]["pos"], graph.nodes[node_b]["pos"])
-                        if dist < min_dist:
-                            min_dist = dist
-                            closest_pair = (node_a, node_b)
-                graph.add_edge(closest_pair[0], closest_pair[1], weight=min_dist)
-
-            print("Connect components in order of component labels.")
-
-        start_node, end_node = find_most_distant_nodes(graph)
-
-        # compare y-value to not get into confusion with MoBIE dimensions
-        if graph.nodes[start_node]["pos"][1] > graph.nodes[end_node]["pos"][1]:
-            apex_node = start_node if apex_higher else end_node
-            base_node = end_node if apex_higher else start_node
-        else:
-            apex_node = end_node if apex_higher else start_node
-            base_node = start_node if apex_higher else end_node
-
-        path = nx.shortest_path(graph, source=apex_node, target=base_node)
-        path_pos = np.array([graph.nodes[p]["pos"] for p in path])
-        if extension_length is not None:
-            path_extended = []
-            for num in range(len(path_pos) - 1):
-                dist = math.dist(path_pos[num], path_pos[num + 1])
-                extended_space = np.linspace(path_pos[num], path_pos[num + 1], round(dist))
-                path_extended.append(path_pos[num])
-                path_extended.extend(extended_space)
-            path_extended.append(path_pos[-1])
-            path = moving_average_3d(np.array(path_extended), window=3)
-        else:
-            path = moving_average_3d(path_pos, window=5)
-        total_path.append(path)
-
-    # 2) Order paths to have consistent start/end points
-    # Find starting order of first two components
-    c1a = total_path[0][0, :]
-    c1b = total_path[0][-1, :]
-
-    c2a = total_path[1][0, :]
-    c2b = total_path[1][-1, :]
-
-    distances = [math.dist(c1a, c2a), math.dist(c1a, c2b), math.dist(c1b, c2a), math.dist(c1b, c2b)]
-    min_index = distances.index(min(distances))
-    if min_index in [0, 1]:
-        total_path[0] = np.flip(total_path[0], axis=0)
-
-    # Order other components from start to end
-    for num in range(0, len(total_path) - 1):
-        dist_connecting_nodes_1 = math.dist(total_path[num][-1, :], total_path[num + 1][0, :])
-        dist_connecting_nodes_2 = math.dist(total_path[num][-1, :], total_path[num + 1][-1, :])
-        if dist_connecting_nodes_2 < dist_connecting_nodes_1:
-            total_path[num + 1] = np.flip(total_path[num + 1], axis=0)
-
-    # 3) Assign base/apex position to path
-    # compare y-value to not get into confusion with MoBIE dimensions
-    if total_path[0][0, 1] > total_path[-1][-1, 1]:
-        if not apex_higher:
-            total_path.reverse()
-            total_path = [np.flip(t) for t in total_path]
-    elif apex_higher:
-        total_path.reverse()
-        total_path = [np.flip(t) for t in total_path]
-
-    # 4) Assign distance of nodes by skipping intermediate space between separate components
-    total_distance = sum([math.dist(p[num + 1], p[num]) for p in total_path for num in range(len(p) - 1)])
-    path_dict = {}
-    accumulated = 0
-    index = 0
-    for num, pa in enumerate(total_path):
-        if num == 0:
-            path_dict[0] = {"pos": total_path[0][0], "length_fraction": 0}
-        else:
-            path_dict[index] = {"pos": total_path[num][0], "length_fraction": path_dict[index - 1]["length_fraction"]}
-
-        index += 1
-        for enum, p in enumerate(pa[1:]):
-            distance = math.dist(total_path[num][enum], p)
-            accumulated += distance
-            rel_dist = accumulated / total_distance
-            path_dict[index] = {"pos": p, "length_fraction": rel_dist}
-            index += 1
-    path_dict[index - 1] = {"pos": total_path[-1][-1, :], "length_fraction": 1}
-
-    # 5) Concatenate individual paths to form total path
-    path = np.concatenate(total_path, axis=0)
-
-    return total_distance, path, path_dict
-
-
-def find_max_min_distance(coords):
-    """
-    Find the maximum of the minimum distances from each point to any other point.
-
-    Args:
-        coords: Array of shape (n, 3) containing 3D coordinates
-
-    Returns:
-        float: Maximum of the minimum distances
-    """
-    coords = np.array(coords)
-
-    # Compute all pairwise distances using broadcasting
-    # Shape: (n, n, 3) - all pairwise differences
-    diff = coords[:, np.newaxis, :] - coords[np.newaxis, :, :]
-
-    # Compute squared distances (avoiding sqrt for efficiency)
-    squared_distances = np.sum(diff**2, axis=2)
-
-    # Set diagonal to infinity to exclude distance to self
-    np.fill_diagonal(squared_distances, np.inf)
-
-    # Find minimum distance for each point
-    min_distances = np.sqrt(np.min(squared_distances, axis=1))
-
-    # Find the maximum of these minimum distances
-    max_min_distance = np.max(min_distances)
-
-    return max_min_distance
 
 
 def minimal_connection_distance(points):
@@ -551,17 +325,16 @@ def minimal_connection_distance(points):
 
 def measure_run_length_ihcs(
     centroids: np.ndarray,
-    centroids_components: Optional[List[np.ndarray]],
+    centroids_components: Optional[List[np.ndarray]] = None,
     max_edge_distance: float = 30,
     apex_higher: bool = True,
     component_label: List[int] = [1],
-    extension_length: Optional[float] = None,
 ) -> Tuple[float, np.ndarray, dict]:
     """Measure the run lengths of the IHC segmentation
     by determining the shortest path between the most distant nodes of a graph.
     The graph is created based on the maximal edge distance between nodes.
 
-    If the graph consists of more than one connected components, a list of component labels must be supplied.
+    If the graph consists of more than one connected component, a list of component labels must be supplied.
     The components are then connected with edges between nodes of neighboring components which are closest together.
     Gaps between individual components are ignored and do not count towards the path length.
 
@@ -570,7 +343,6 @@ def measure_run_length_ihcs(
         max_edge_distance: Maximal edge distance between graph nodes to create an edge between nodes.
         apex_higher: Flag for identifying apex and base. Apex is set to node with higher y-value if True.
         component_label: List of component labels. Determines the order of components to connect.
-        extension_length: Extend central path between segmentation instances. Adds nodes in regular interval [µm].
 
     Returns:
         Total distance of the path.
@@ -618,6 +390,7 @@ def measure_run_length_ihcs(
         # Order connected components in order of component labels
         # e.g. component_labels = [7, 4, 1, 11] and len_c = [600, 400, 300, 55]
         # get re-ordered to [300, 400, 600, 55]
+        # TODO: Find more robust way to sort components
         components_sorted = [
             c[1] for _, c in sorted(zip(sorted(range(len(component_label)), key=lambda i: component_label[i]),
                                         sorted(zip(len_c, components), key=lambda x: x[0], reverse=True)))]
@@ -651,19 +424,7 @@ def measure_run_length_ihcs(
     path = nx.shortest_path(graph, source=apex_node, target=base_node)
     total_distance = nx.path_weight(graph, path, weight="weight")
     path_pos = [graph.nodes[p]["pos"] for p in path]
-
-    if extension_length is not None:
-        path_extended = []
-        for num in range(len(path_pos) - 1):
-            dist = math.dist(path_pos[num], path_pos[num + 1])
-            extended_space = np.linspace(path_pos[num], path_pos[num + 1], round(dist))
-            path_extended.append(path_pos[num])
-            path_extended.extend(extended_space)
-        path_extended.append(path_pos[-1])
-        path = moving_average_3d(np.array(path_extended), window=3)
-        path_pos = path_extended
-    else:
-        path = moving_average_3d(np.array(path_pos), window=5)
+    path = moving_average_3d(path_pos, window=3)
 
     # assign relative distance to points on path
     path_dict = {}
@@ -867,7 +628,7 @@ def equidistant_centers(
     centroids = list(zip(new_subset["anchor_x"], new_subset["anchor_y"], new_subset["anchor_z"]))
 
     if cell_type == "ihc":
-        if len(component_label) == 1:
+        if len(component_label) != 1:
             total_distance, path, _ = measure_run_length_ihcs(
                 centroids, component_label=component_label,
             )
@@ -878,23 +639,21 @@ def equidistant_centers(
                 subset = table[table["component_labels"] == label]
                 subset_centroids = list(zip(subset["anchor_x"], subset["anchor_y"], subset["anchor_z"]))
                 centroids_components.append(subset_centroids)
-            total_distance, path, path_dict = measure_run_length_ihcs_multi_component(
-                centroids_components, skip_gap=True,
+            total_distance, path, path_dict = measure_run_length_ihcs(
+                centroids_components,
             )
             return get_centers_from_path_dict(path_dict, n_blocks=n_blocks, offset_blocks=offset_blocks)
 
     else:
+        centroids_components = []
+        for label in component_label:
+            subset = table[table["component_labels"] == label]
+            subset_centroids = list(zip(subset["anchor_x"], subset["anchor_y"], subset["anchor_z"]))
+            centroids_components.append(subset_centroids)
+        total_distance, path, path_dict = measure_run_length_sgns(centroids_components)
         if len(component_label) == 1:
-            total_distance, path, _ = measure_run_length_sgns(centroids)
             return get_centers_from_path(path, total_distance, n_blocks=n_blocks, offset_blocks=offset_blocks)
-
         else:
-            centroids_components = []
-            for label in component_label:
-                subset = table[table["component_labels"] == label]
-                subset_centroids = list(zip(subset["anchor_x"], subset["anchor_y"], subset["anchor_z"]))
-                centroids_components.append(subset_centroids)
-            total_distance, path, path_dict = measure_run_length_sgns_multi_component(centroids_components)
             return get_centers_from_path_dict(path_dict, n_blocks=n_blocks, offset_blocks=offset_blocks)
 
 
@@ -907,7 +666,6 @@ def tonotopic_mapping(
     apex_higher: bool = True,
     otof: bool = False,
     central_path_df: Optional[pd.DataFrame] = None,
-    extension_length: Optional[float] = None,
 ) -> pd.DataFrame:
     """Tonotopic mapping of SGNs or IHCs by supplying a table with component labels.
     The mapping assigns a tonotopic label to each instance according to the position along the length of the cochlea.
@@ -921,7 +679,6 @@ def tonotopic_mapping(
         apex_higher: Flag for identifying apex and base. Apex is set to node with higher y-value if True.
         otof: Use mapping by *Mueller, Hearing Research 202 (2005) 63-73* for OTOF cochleae.
         central_path_df: Dataframe featuring the spots for the central path through the segmentation.
-        extension_length: Extend central path between segmentation instances. Adds nodes in regular interval [µm].
 
     Returns:
         Table with tonotopic label for cells.
@@ -936,7 +693,7 @@ def tonotopic_mapping(
 
     if central_path_df is None:
 
-        if cell_type == "ihc":
+        if cell_type in ["ihc", "IHC"]:
             centroids_components = []
             for label in component_mapping:
                 subset = table[table["component_labels"] == label]
@@ -945,26 +702,20 @@ def tonotopic_mapping(
 
             total_distance, _, path_dict = measure_run_length_ihcs(
                 centroids, centroids_components, component_label=component_label, apex_higher=apex_higher,
-                extension_length=extension_length,
+            )
+
+        elif cell_type in ["sgn", "SGN"]:
+            centroids_components = []
+            for label in component_mapping:
+                subset = table[table["component_labels"] == label]
+                subset_centroids = list(zip(subset["anchor_x"], subset["anchor_y"], subset["anchor_z"]))
+                centroids_components.append(subset_centroids)
+            total_distance, _, path_dict = measure_run_length_sgns(
+                centroids_components, apex_higher=apex_higher,
             )
 
         else:
-            if len(component_mapping) == 1:
-                total_distance, _, path_dict = measure_run_length_sgns(
-                    centroids, apex_higher=apex_higher,
-                    extension_length=extension_length,
-                )
-
-            else:
-                centroids_components = []
-                for label in component_mapping:
-                    subset = table[table["component_labels"] == label]
-                    subset_centroids = list(zip(subset["anchor_x"], subset["anchor_y"], subset["anchor_z"]))
-                    centroids_components.append(subset_centroids)
-                total_distance, _, path_dict = measure_run_length_sgns_multi_component(
-                    centroids_components, apex_higher=apex_higher,
-                    extension_length=extension_length,
-                )
+            raise ValueError(f"Unrecognized cell type: {cell_type}. Choose either 'sgn' or 'ihc'.")
 
         for key, items in path_dict.items():
             path_dict[key]["length[µm]"] = items["length_fraction"] * total_distance
@@ -974,6 +725,7 @@ def tonotopic_mapping(
         central_path_df = path_dict_to_central_path_table(path_dict)
     else:
         path_dict = central_path_table_to_path_dict(central_path_df)
+        path_dict = map_frequency(path_dict, animal=animal, otof=otof)
         node_dict = node_dict_from_path_dict(path_dict, label_ids, centroids)
 
     offset = [-1 for _ in range(len(table))]
@@ -1080,11 +832,10 @@ def tonotopic_mapping_single(
                                                    cell_type=cell_type, component_mapping=component_mapping,
                                                    apex_higher=apex_higher,
                                                    central_path_df=central_path_df,
-                                                   otof=otof,
-                                                   extension_length=1)
+                                                   otof=otof)
 
         table.to_csv(out_path, sep="\t", index=False)
-        if central_spots_path is not None and not os.path.isfile(out_path):
+        if central_spots_path is not None and not os.path.isfile(central_spots_path):
             print("Saving path", central_spots_path)
             central_path_df.to_csv(central_spots_path, sep="\t", index=False)
 

--- a/flamingo_tools/postprocessing/cochlea_mapping.py
+++ b/flamingo_tools/postprocessing/cochlea_mapping.py
@@ -265,6 +265,7 @@ def measure_run_length_sgns(
         centroids: np.ndarray,
         scale_factor: int = 10,
         apex_higher: bool = True,
+        extension_length: Optional[float] = None,
 ) -> Tuple[float, np.ndarray, dict]:
     """Measure the run lengths of the SGN segmentation by finding a central path through Rosenthal's canal.
     1) Create a binary mask based on down-scaled centroids.
@@ -279,6 +280,7 @@ def measure_run_length_sgns(
         centroids: Centroids of the SGN segmentation, ndarray of shape (N, 3).
         scale_factor: Downscaling factor for finding the central path.
         apex_higher: Flag for identifying apex and base. Apex is set to node with higher y-value if True.
+        extension_length: Extend central path between segmentation instances. Adds nodes in regular interval [µm].
 
     Returns:
         Total distance of the path.
@@ -313,8 +315,20 @@ def measure_run_length_sgns(
     # 5) Identify a central path based on the 3D Euclidean distance transform.
     path = central_path_edt_graph(mask, apex, base)
     # 6) The path is up-scaled and smoothed using a moving average filter.
-    path = path * scale_factor
-    path = moving_average_3d(path, window=5)
+    path_pos = path * scale_factor
+
+    if extension_length is not None:
+        path_extended = []
+        for num in range(len(path_pos) - 1):
+            dist = math.dist(path_pos[num], path_pos[num + 1])
+            extended_space = np.linspace(path_pos[num], path_pos[num + 1], round(dist))
+            path_extended.append(path_pos[num])
+            path_extended.extend(extended_space)
+        path_extended.append(path_pos[-1])
+        path = moving_average_3d(np.array(path_extended), window=3)
+    else:
+        path = moving_average_3d(path_pos, window=5)
+
     total_distance = sum([math.dist(path[num + 1], path[num]) for num in range(len(path) - 1)])
 
     # 7) The points of the path are fed into a dictionary along with the fractional length.
@@ -336,6 +350,7 @@ def measure_run_length_ihcs_multi_component(
     max_edge_distance: float = 30,
     apex_higher: bool = True,
     component_label: List[int] = [1],
+    extension_length: Optional[float] = None,
 ) -> Tuple[float, np.ndarray, dict]:
     """Adaptation of measure_run_length_sgns_multi_component to IHCs.
 
@@ -408,7 +423,17 @@ def measure_run_length_ihcs_multi_component(
 
         path = nx.shortest_path(graph, source=apex_node, target=base_node)
         path_pos = np.array([graph.nodes[p]["pos"] for p in path])
-        path = moving_average_3d(path_pos, window=5)
+        if extension_length is not None:
+            path_extended = []
+            for num in range(len(path_pos) - 1):
+                dist = math.dist(path_pos[num], path_pos[num + 1])
+                extended_space = np.linspace(path_pos[num], path_pos[num + 1], round(dist))
+                path_extended.append(path_pos[num])
+                path_extended.extend(extended_space)
+            path_extended.append(path_pos[-1])
+            path = moving_average_3d(np.array(path_extended), window=3)
+        else:
+            path = moving_average_3d(path_pos, window=5)
         total_path.append(path)
 
     # 2) Order paths to have consistent start/end points
@@ -530,6 +555,7 @@ def measure_run_length_ihcs(
     max_edge_distance: float = 30,
     apex_higher: bool = True,
     component_label: List[int] = [1],
+    extension_length: Optional[float] = None,
 ) -> Tuple[float, np.ndarray, dict]:
     """Measure the run lengths of the IHC segmentation
     by determining the shortest path between the most distant nodes of a graph.
@@ -544,6 +570,7 @@ def measure_run_length_ihcs(
         max_edge_distance: Maximal edge distance between graph nodes to create an edge between nodes.
         apex_higher: Flag for identifying apex and base. Apex is set to node with higher y-value if True.
         component_label: List of component labels. Determines the order of components to connect.
+        extension_length: Extend central path between segmentation instances. Adds nodes in regular interval [µm].
 
     Returns:
         Total distance of the path.
@@ -623,20 +650,31 @@ def measure_run_length_ihcs(
 
     path = nx.shortest_path(graph, source=apex_node, target=base_node)
     total_distance = nx.path_weight(graph, path, weight="weight")
+    path_pos = [graph.nodes[p]["pos"] for p in path]
+
+    if extension_length is not None:
+        path_extended = []
+        for num in range(len(path_pos) - 1):
+            dist = math.dist(path_pos[num], path_pos[num + 1])
+            extended_space = np.linspace(path_pos[num], path_pos[num + 1], round(dist))
+            path_extended.append(path_pos[num])
+            path_extended.extend(extended_space)
+        path_extended.append(path_pos[-1])
+        path = moving_average_3d(np.array(path_extended), window=3)
+        path_pos = path_extended
+    else:
+        path = moving_average_3d(np.array(path_pos), window=5)
 
     # assign relative distance to points on path
     path_dict = {}
-    path_dict[0] = {"pos": graph.nodes[path[0]]["pos"], "length_fraction": 0}
+    path_dict[0] = {"pos": path_pos[0], "length_fraction": 0}
     accumulated = 0
-    for num, p in enumerate(path[1:-1]):
-        distance = math.dist(graph.nodes[path[num]]["pos"], graph.nodes[p]["pos"])
+    for num, p in enumerate(path_pos[1:-1]):
+        distance = math.dist(path_pos[num], p)
         accumulated += distance
         rel_dist = accumulated / total_distance
-        path_dict[num + 1] = {"pos": graph.nodes[p]["pos"], "length_fraction": rel_dist}
-    path_dict[len(path)] = {"pos": graph.nodes[path[-1]]["pos"], "length_fraction": 1}
-
-    path_pos = np.array([graph.nodes[p]["pos"] for p in path])
-    path = moving_average_3d(path_pos, window=5)
+        path_dict[num + 1] = {"pos": p, "length_fraction": rel_dist}
+    path_dict[len(path_pos)] = {"pos": path_pos[-1], "length_fraction": 1}
 
     return total_distance, path, path_dict
 
@@ -869,6 +907,7 @@ def tonotopic_mapping(
     apex_higher: bool = True,
     otof: bool = False,
     central_path_df: Optional[pd.DataFrame] = None,
+    extension_length: Optional[float] = None,
 ) -> pd.DataFrame:
     """Tonotopic mapping of SGNs or IHCs by supplying a table with component labels.
     The mapping assigns a tonotopic label to each instance according to the position along the length of the cochlea.
@@ -882,6 +921,7 @@ def tonotopic_mapping(
         apex_higher: Flag for identifying apex and base. Apex is set to node with higher y-value if True.
         otof: Use mapping by *Mueller, Hearing Research 202 (2005) 63-73* for OTOF cochleae.
         central_path_df: Dataframe featuring the spots for the central path through the segmentation.
+        extension_length: Extend central path between segmentation instances. Adds nodes in regular interval [µm].
 
     Returns:
         Table with tonotopic label for cells.
@@ -905,12 +945,14 @@ def tonotopic_mapping(
 
             total_distance, _, path_dict = measure_run_length_ihcs(
                 centroids, centroids_components, component_label=component_label, apex_higher=apex_higher,
+                extension_length=extension_length,
             )
 
         else:
             if len(component_mapping) == 1:
                 total_distance, _, path_dict = measure_run_length_sgns(
                     centroids, apex_higher=apex_higher,
+                    extension_length=extension_length,
                 )
 
             else:
@@ -921,6 +963,7 @@ def tonotopic_mapping(
                     centroids_components.append(subset_centroids)
                 total_distance, _, path_dict = measure_run_length_sgns_multi_component(
                     centroids_components, apex_higher=apex_higher,
+                    extension_length=extension_length,
                 )
 
         for key, items in path_dict.items():
@@ -931,6 +974,7 @@ def tonotopic_mapping(
         central_path_df = path_dict_to_central_path_table(path_dict)
     else:
         path_dict = central_path_table_to_path_dict(central_path_df)
+        node_dict = node_dict_from_path_dict(path_dict, label_ids, centroids)
 
     offset = [-1 for _ in range(len(table))]
     offset = list(np.float64(offset))
@@ -1036,10 +1080,12 @@ def tonotopic_mapping_single(
                                                    cell_type=cell_type, component_mapping=component_mapping,
                                                    apex_higher=apex_higher,
                                                    central_path_df=central_path_df,
-                                                   otof=otof)
+                                                   otof=otof,
+                                                   extension_length=1)
 
         table.to_csv(out_path, sep="\t", index=False)
-        if central_spots_path is not None:
+        if central_spots_path is not None and not os.path.isfile(out_path):
+            print("Saving path", central_spots_path)
             central_path_df.to_csv(central_spots_path, sep="\t", index=False)
 
 
@@ -1122,7 +1168,7 @@ def tonotopic_mapping_json_wrapper(
     table_path: Optional[str] = None,
     json_file: Optional[str] = None,
     central_spots_path: Optional[str] = None,
-    force: bool = False,
+    force_overwrite: bool = False,
     animal: str = "mouse",
     otof: bool = False,
     s3: bool = False,
@@ -1145,7 +1191,7 @@ def tonotopic_mapping_json_wrapper(
     if json_file is None:
         tonotopic_mapping_single(table_path, out_path=out_path, animal=animal, ototf=otof,
                                  central_spots_path=central_spots_path,
-                                 force_overwrite=force, s3=s3, **kwargs)
+                                 force_overwrite=force_overwrite, s3=s3, **kwargs)
     else:
         if out_path is None:
             raise ValueError("Specify an output path when supplying a JSON dictionary.")
@@ -1173,11 +1219,10 @@ def tonotopic_mapping_json_wrapper(
                 cochlea_str = cochlea.replace('_', '-')
                 table_str = seg_channel.replace('_', '-')
                 save_path = os.path.join(out_path, "_".join([cochlea_str, f"{table_str}.tsv"]))
-                if central_spots_path is None:
-                    central_spots_path = os.path.join(out_path, "_".join([cochlea_str, f"{table_str}_path.tsv"]))
+                # central_spots_path = os.path.join(out_path, "_".join([cochlea_str, f"{table_str}_path.tsv"]))
             else:
                 save_path = out_path
 
             tonotopic_mapping_single(table_path=table_path, out_path=save_path, animal=animal, otof=otof,
-                                     force_overwrite=force, central_spots_path=central_spots_path,
+                                     force_overwrite=force_overwrite, central_spots_path=central_spots_path,
                                      s3=s3, **params)

--- a/flamingo_tools/postprocessing/cochlea_mapping.py
+++ b/flamingo_tools/postprocessing/cochlea_mapping.py
@@ -122,6 +122,8 @@ def moving_average_3d(path: np.ndarray, window: int = 3) -> np.ndarray:
     Returns:
         smoothed path: ndarray of same shape.
     """
+    if not isinstance(path, np.ndarray):
+        path = np.array(path)
     kernel_size = 2 * window + 1
     kernel = np.ones(kernel_size) / kernel_size
 

--- a/flamingo_tools/postprocessing/cochlea_mapping.py
+++ b/flamingo_tools/postprocessing/cochlea_mapping.py
@@ -14,6 +14,36 @@ from flamingo_tools.postprocessing.label_components import downscaled_centroids
 from flamingo_tools.s3_utils import get_s3_path
 
 
+def path_dict_to_central_path_table(path_dict):
+    central_path_dict = []
+    for key, item in path_dict.items():
+        dict_tmp = {}
+        dict_tmp["spot_id"] = key
+        pos = item["pos"]
+        dict_tmp["x"] = int(round(pos[0]))
+        dict_tmp["y"] = int(round(pos[1]))
+        dict_tmp["z"] = int(round(pos[2]))
+        dict_tmp["length_fraction"] = item["length_fraction"]
+        dict_tmp["length[µm]"] = item["length[µm]"]
+        dict_tmp["frequency[kHz]"] = item["frequency[kHz]"]
+        central_path_dict.append(dict_tmp)
+
+    return pd.DataFrame(central_path_dict)
+
+
+def central_path_table_to_path_dict(central_path_df):
+    path_dict = {}
+    for _, row in central_path_df.iterrows():
+        ddict = {}
+        ddict["pos"] = (row["x"], row["y"], row["z"])
+        ddict["length_fraction"] = row["length_fraction"]
+        ddict["length[µm]"] = row["length[µm]"]
+        ddict["frequency[kHz]"] = row["frequency[kHz]"]
+        spot_id = int(row["spot_id"])
+        path_dict[spot_id] = ddict
+    return path_dict
+
+
 def find_most_distant_nodes(G: nx.classes.graph.Graph, weight: str = 'weight') -> Tuple[float, float]:
     """Find the most distant nodes in a graph.
 
@@ -611,7 +641,7 @@ def measure_run_length_ihcs(
     return total_distance, path, path_dict
 
 
-def map_frequency(table: pd.DataFrame, animal: str = "mouse", otof: bool = False) -> pd.DataFrame:
+def map_frequency(path_dict: dict, animal: str = "mouse", otof: bool = False) -> pd.DataFrame:
     """Map the frequency range of SGNs in the cochlea
     using Greenwood function f(x) = A * (10 **(ax) - K).
     Values for humans: a=2.1, k=0.88, A = 165.4 [kHz].
@@ -625,7 +655,23 @@ def map_frequency(table: pd.DataFrame, animal: str = "mouse", otof: bool = False
     Returns:
         Dataframe containing frequency in an additional column 'frequency[kHz]'.
     """
-    if animal == "mouse":
+    if otof and animal == "mouse":
+        # freq_min = 4.84 kHz
+        # freq_max = 78.8 kHz
+        # Mueller, Hearing Research 202 (2005) 63-73, https://doi.org/10.1016/j.heares.2004.08.011
+        # function has format f(x) = 10 ** (a * (k - (1-x)))
+        var_a = 100 / 82.5
+        var_k = 1.565
+        var_A = 1
+        # bring it into same format as previous equation:
+        # f(x) = 10 ** (a * (k - (1-x)))
+        # f(x) = 10 ** (ax - (-a * (k-1)))
+        # f(x) = 10 ** (ax - c) with c = (-a * (k-1))
+        var_a = 100 / 82.5
+        var_k = -0.684848485
+        var_A = 1
+
+    elif animal == "mouse":
         # freq_min = 1.5 kHz
         # freq_max = 86 kHz
         # ou bohne 2000 Hear res, "EDGES"
@@ -644,29 +690,10 @@ def map_frequency(table: pd.DataFrame, animal: str = "mouse", otof: bool = False
     else:
         raise ValueError("Animal not supported. Use either 'mouse' or 'gerbil'.")
 
-    table.loc[table['offset'] >= 0, 'frequency[kHz]'] = var_A * (10 ** (var_a * table["length_fraction"]) - var_k)
-    table.loc[table['offset'] < 0, 'frequency[kHz]'] = 0
+    for key in path_dict.keys():
+        path_dict[key]["frequency[kHz]"] = var_A * (10 ** (var_a * path_dict[key]["length_fraction"]) - var_k)
 
-    if otof and animal == "mouse":
-        # freq_min = 4.84 kHz
-        # freq_max = 78.8 kHz
-        # Mueller, Hearing Research 202 (2005) 63-73, https://doi.org/10.1016/j.heares.2004.08.011
-        # function has format f(x) = 10 ** (a * (k - (1-x)))
-        var_a = 100 / 82.5
-        var_k = 1.565
-        var_A = 1
-        # bring it into same format as previous equation:
-        # f(x) = 10 ** (a * (k - (1-x)))
-        # f(x) = 10 ** (ax - (-a * (k-1)))
-        # f(x) = 10 ** (ax - c) with c = (-a * (k-1))
-        var_a = 100 / 82.5
-        var_k = -0.684848485
-        var_A = 1
-        table.loc[table['offset'] >= 0, 'frequency[kHz]'] = var_A * (10 ** (var_a * table["length_fraction"]) - var_k)
-
-        table.loc[table['offset'] < 0, 'frequency-mueller[kHz]'] = 0
-
-    return table
+    return path_dict
 
 
 def get_centers_from_path(
@@ -770,7 +797,9 @@ def node_dict_from_path_dict(
         node_dict[c] = {
             "label_id": c,
             "length_fraction": path_dict[nearest_node]["length_fraction"],
-            "pos": path_dict[nearest_node]["length_fraction"],
+            "length[µm]": path_dict[nearest_node]["length[µm]"],
+            "pos": path_dict[nearest_node]["pos"],
+            "frequency[kHz]": path_dict[nearest_node]["frequency[kHz]"],
             "offset": min_dist,
         }
     return node_dict
@@ -839,6 +868,7 @@ def tonotopic_mapping(
     animal: str = "mouse",
     apex_higher: bool = True,
     otof: bool = False,
+    central_path_df: Optional[pd.DataFrame] = None,
 ) -> pd.DataFrame:
     """Tonotopic mapping of SGNs or IHCs by supplying a table with component labels.
     The mapping assigns a tonotopic label to each instance according to the position along the length of the cochlea.
@@ -851,6 +881,7 @@ def tonotopic_mapping(
         animal: Animal specifier for species specific frequency mapping. Either "mouse" or "gerbil".
         apex_higher: Flag for identifying apex and base. Apex is set to node with higher y-value if True.
         otof: Use mapping by *Mueller, Hearing Research 202 (2005) 63-73* for OTOF cochleae.
+        central_path_df: Dataframe featuring the spots for the central path through the segmentation.
 
     Returns:
         Table with tonotopic label for cells.
@@ -863,53 +894,67 @@ def tonotopic_mapping(
     if component_mapping is None:
         component_mapping = component_label
 
-    if cell_type == "ihc":
-        centroids_components = []
-        for label in component_mapping:
-            subset = table[table["component_labels"] == label]
-            subset_centroids = list(zip(subset["anchor_x"], subset["anchor_y"], subset["anchor_z"]))
-            centroids_components.append(subset_centroids)
+    if central_path_df is None:
 
-        total_distance, _, path_dict = measure_run_length_ihcs(
-            centroids, centroids_components, component_label=component_label, apex_higher=apex_higher,
-        )
-
-    else:
-        if len(component_mapping) == 1:
-            total_distance, _, path_dict = measure_run_length_sgns(
-                centroids, apex_higher=apex_higher,
-            )
-
-        else:
+        if cell_type == "ihc":
             centroids_components = []
             for label in component_mapping:
                 subset = table[table["component_labels"] == label]
                 subset_centroids = list(zip(subset["anchor_x"], subset["anchor_y"], subset["anchor_z"]))
                 centroids_components.append(subset_centroids)
-            total_distance, _, path_dict = measure_run_length_sgns_multi_component(
-                centroids_components, apex_higher=apex_higher,
+
+            total_distance, _, path_dict = measure_run_length_ihcs(
+                centroids, centroids_components, component_label=component_label, apex_higher=apex_higher,
             )
 
-    node_dict = node_dict_from_path_dict(path_dict, label_ids, centroids)
+        else:
+            if len(component_mapping) == 1:
+                total_distance, _, path_dict = measure_run_length_sgns(
+                    centroids, apex_higher=apex_higher,
+                )
+
+            else:
+                centroids_components = []
+                for label in component_mapping:
+                    subset = table[table["component_labels"] == label]
+                    subset_centroids = list(zip(subset["anchor_x"], subset["anchor_y"], subset["anchor_z"]))
+                    centroids_components.append(subset_centroids)
+                total_distance, _, path_dict = measure_run_length_sgns_multi_component(
+                    centroids_components, apex_higher=apex_higher,
+                )
+
+        for key, items in path_dict.items():
+            path_dict[key]["length[µm]"] = items["length_fraction"] * total_distance
+
+        path_dict = map_frequency(path_dict, animal=animal, otof=otof)
+        node_dict = node_dict_from_path_dict(path_dict, label_ids, centroids)
+        central_path_df = path_dict_to_central_path_table(path_dict)
+    else:
+        path_dict = central_path_table_to_path_dict(central_path_df)
 
     offset = [-1 for _ in range(len(table))]
     offset = list(np.float64(offset))
     table.loc[:, "offset"] = offset
-    # 'label_id' of dataframe starting at 1
-    for key in list(node_dict.keys()):
-        table.loc[table["label_id"] == key, "offset"] = node_dict[key]["offset"]
 
     length_fraction = [0 for _ in range(len(table))]
     length_fraction = list(np.float64(length_fraction))
     table.loc[:, "length_fraction"] = length_fraction
-    for num, key in enumerate(list(node_dict.keys())):
+
+    length_abs = [0 for _ in range(len(table))]
+    length_abs = list(np.float64(length_abs))
+    table.loc[:, "length[µm]"] = length_abs
+
+    frequency = [0 for _ in range(len(table))]
+    frequency = list(np.float64(frequency))
+    table.loc[:, "frequency[kHz]"] = frequency
+
+    for key in list(node_dict.keys()):
+        table.loc[table["label_id"] == key, "offset"] = node_dict[key]["offset"]
         table.loc[table["label_id"] == key, "length_fraction"] = node_dict[key]["length_fraction"]
+        table.loc[table["label_id"] == key, "length[µm]"] = node_dict[key]["length[µm]"]
+        table.loc[table["label_id"] == key, "frequency[kHz]"] = node_dict[key]["frequency[kHz]"]
 
-    table.loc[:, "length[µm]"] = table["length_fraction"] * total_distance
-
-    table = map_frequency(table, animal=animal, otof=otof)
-
-    return table
+    return table, central_path_df
 
 
 def tonotopic_mapping_single(
@@ -922,6 +967,7 @@ def tonotopic_mapping_single(
     apex_position: str = "apex_higher",
     component_list: List[int] = [1],
     component_mapping: Optional[List[int]] = None,
+    central_spots_path: Optional[str] = None,
     s3: bool = False,
     s3_credentials: Optional[str] = None,
     s3_bucket_name: Optional[str] = None,
@@ -946,7 +992,8 @@ def tonotopic_mapping_single(
         otof: Use mapping by *Mueller, Hearing Research 202 (2005) 63-73* for OTOF cochleae.
         apex_position: Identify position of apex and base. Apex is set to node with higher y-value per default.
         component_list: List of components. Can be passed to obtain the number of instances within the component list.
-        components_mapping: Components to use for tonotopic mapping. Ignore components torn parallel to main canal.
+        component_mapping: Components to use for tonotopic mapping. Ignore components torn parallel to main canal.
+        central_spots_path: Provide table featuring spots for central path through segmentation for tonotopic mapping.
         s3: Use S3 bucket.
         s3_credentials:
         s3_bucket_name:
@@ -970,6 +1017,11 @@ def tonotopic_mapping_single(
     else:
         table = pd.read_csv(table_path, sep="\t")
 
+    if central_spots_path is not None and os.path.isfile(central_spots_path):
+        central_path_df = pd.read_csv(central_spots_path, sep="\t")
+    else:
+        central_path_df = None
+
     apex_higher = (apex_position == "apex_higher")
 
     # overwrite input file
@@ -980,12 +1032,15 @@ def tonotopic_mapping_single(
         print(f"Skipping {out_path}. Table already exists.")
 
     else:
-        table = tonotopic_mapping(table, component_label=component_list, animal=animal,
-                                  cell_type=cell_type, component_mapping=component_mapping,
-                                  apex_higher=apex_higher,
-                                  otof=otof)
+        table, central_path_df = tonotopic_mapping(table, component_label=component_list, animal=animal,
+                                                   cell_type=cell_type, component_mapping=component_mapping,
+                                                   apex_higher=apex_higher,
+                                                   central_path_df=central_path_df,
+                                                   otof=otof)
 
         table.to_csv(out_path, sep="\t", index=False)
+        if central_spots_path is not None:
+            central_path_df.to_csv(central_spots_path, sep="\t", index=False)
 
 
 def equidistant_centers_single(
@@ -1053,3 +1108,76 @@ def equidistant_centers_single(
 
     with open(output_path, "w") as f:
         json.dump(dic, f, indent='\t', separators=(',', ': '))
+
+
+def _load_json_as_list(ddict_path: str) -> List[dict]:
+    with open(ddict_path, "r") as f:
+        data = json.loads(f.read())
+    # ensure the result is always a list
+    return data if isinstance(data, list) else [data]
+
+
+def tonotopic_mapping_json_wrapper(
+    out_path: str,
+    table_path: Optional[str] = None,
+    json_file: Optional[str] = None,
+    central_spots_path: Optional[str] = None,
+    force: bool = False,
+    animal: str = "mouse",
+    otof: bool = False,
+    s3: bool = False,
+    **kwargs
+):
+    """Wrapper function for tonotopic mapping using a segmentation table.
+    The function is used to distinguish between a passed parameter dictionary in JSON format
+    and the explicit setting of parameters.
+
+    Args:
+        output_path: Output path to segmentation table with new column "component_labels".
+        table_path: File path to segmentation table.
+        json_file: JSON file containing parameters for tonotopic mapping.
+        central_spots_path: Provide table featuring spots for central path through segmentation for tonotopic mapping.
+        force: Forcefully overwrite existing output path.
+        animal: Animal specifier for species specific frequency mapping. Either "mouse" or "gerbil".
+        otof: Use mapping by *Mueller, Hearing Research 202 (2005) 63-73* for OTOF cochleae.
+        s3: Use data path of S3 bucket for segmentation table.
+    """
+    if json_file is None:
+        tonotopic_mapping_single(table_path, out_path=out_path, animal=animal, ototf=otof,
+                                 central_spots_path=central_spots_path,
+                                 force_overwrite=force, s3=s3, **kwargs)
+    else:
+        if out_path is None:
+            raise ValueError("Specify an output path when supplying a JSON dictionary.")
+        param_dicts = _load_json_as_list(json_file)
+        for params in param_dicts:
+
+            cochlea = params["dataset_name"]
+            print(f"\n{cochlea}")
+            seg_channel = params["segmentation_channel"]
+            table_path = os.path.join(f"{cochlea}", "tables", seg_channel, "default.tsv")
+
+            if "OTOF" in cochlea:
+                otof = True
+            else:
+                otof = False
+
+            if cochlea[0] in ["M", "m"]:
+                animal = "mouse"
+            elif cochlea[0] in ["G", "g"]:
+                animal = "gerbil"
+            else:
+                animal = "mouse"
+
+            if os.path.isdir(out_path):
+                cochlea_str = cochlea.replace('_', '-')
+                table_str = seg_channel.replace('_', '-')
+                save_path = os.path.join(out_path, "_".join([cochlea_str, f"{table_str}.tsv"]))
+                if central_spots_path is None:
+                    central_spots_path = os.path.join(out_path, "_".join([cochlea_str, f"{table_str}_path.tsv"]))
+            else:
+                save_path = out_path
+
+            tonotopic_mapping_single(table_path=table_path, out_path=save_path, animal=animal, otof=otof,
+                                     force_overwrite=force, central_spots_path=central_spots_path,
+                                     s3=s3, **params)

--- a/reproducibility/tonotopic_mapping/repro_tonotopic_mapping.py
+++ b/reproducibility/tonotopic_mapping/repro_tonotopic_mapping.py
@@ -17,6 +17,7 @@ def wrapper_tonotopic_mapping(
     output_path: str,
     table_path: Optional[str] = None,
     ddict: Optional[str] = None,
+    central_spots_path: Optional[str] = None,
     force_overwrite: bool = False,
     animal: str = "mouse",
     otof: bool = False,
@@ -65,11 +66,14 @@ def wrapper_tonotopic_mapping(
                 cochlea_str = cochlea.replace('_', '-')
                 table_str = seg_channel.replace('_', '-')
                 save_path = os.path.join(output_path, "_".join([cochlea_str, f"{table_str}.tsv"]))
+                if central_spots_path is None:
+                    central_spots_path = os.path.join(output_path, "_".join([cochlea_str, f"{table_str}_path.tsv"]))
             else:
                 save_path = output_path
 
             tonotopic_mapping_single(table_path=table_path, out_path=save_path, animal=animal, otof=otof,
-                                     force_overwrite=force_overwrite, s3=s3, **params)
+                                     force_overwrite=force_overwrite, central_spots_path=central_spots_path,
+                                     s3=s3, **params)
 
 
 def main():
@@ -129,5 +133,4 @@ def main():
 
 
 if __name__ == "__main__":
-
     main()

--- a/scripts/analysis/edit_central_path.py
+++ b/scripts/analysis/edit_central_path.py
@@ -1,0 +1,42 @@
+import argparse
+
+from flamingo_tools.analysis.central_path_utils import insert_coordinates_to_central_path
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--input", type=str, required=True,
+                        help="Input path to table with central path spots.")
+    parser.add_argument("-o", "--output", type=str, required=True,
+                        help="Output path to main table.")
+    parser.add_argument("-c", "--coordinates", type=str, nargs="+", default=None,
+                        help="List of coordinates, coordinates are seperated by comma, e.g. 100,340,87.")
+
+    # options for data access on S3 bucket
+    parser.add_argument("--s3", action="store_true", help="Flag for using S3 bucket.")
+    parser.add_argument("--s3_credentials", type=str, default=None,
+                        help="Input file containing S3 credentials. "
+                        "Optional if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY were exported.")
+    parser.add_argument("--s3_bucket_name", type=str, default=None,
+                        help="S3 bucket name. Optional if BUCKET_NAME was exported.")
+    parser.add_argument("--s3_service_endpoint", type=str, default=None,
+                        help="S3 service endpoint. Optional if SERVICE_ENDPOINT was exported.")
+
+    args = parser.parse_args()
+
+    if args.coordinates is not None:
+        coordinates = [[float(c) for c in coord_str.split(",")] for coord_str in args.coordinates]
+
+        insert_coordinates_to_central_path(
+            table_path=args.input,
+            output_path=args.output,
+            coordinates=coordinates,
+            s3=args.s3,
+            s3_credentials=args.s3_credentials,
+            s3_bucket_name=args.s3_bucket_name,
+            s3_service_endpoint=args.s3_service_endpoint,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The aim of this branch is to extend the functionality of tonotopic mapping to enable the central path used for the mapping to be exported and imported.
This would enable the path coordinates to be manually edited to account for broken cochleae with separated components or those with degenerated SGNs.