### PR TITLE
CLI function to download models to cache

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -47,6 +47,38 @@ pip install .
 ```
 conda install -c conda-forge napari pyqt
 ```
+## Available Models
+
+CochleaNet provides four different segmentation models:
+- `SGN`: for segmenting spiral ganglion neurons (SGNs) in high-resolution, isotropic light-sheet microscopy data.
+    - This model was trained on image data with parvalbumin (PV) stain, with a voxel size of 0.38 micrometer.
+- `IHC`: for segmenting inner hair cells (IHCs) in high-resolution, isotropic light-sheet microscopy data.
+    - This model was trained on image data with Vglut3 stain, with a voxel size of 0.38 micrometer.
+- `SGN-lowres`: for segmenting SGNs in lower-resolution, anisotropic light-sheet microscopy data.
+    - This model was trained on image data with PV stain, with a voxel size of 0.76 X 0.76 X 3.0 micrometer.
+- `IHC-lowres`: for segmenting IHCs in lower-resolution, anisotropic light-sheet microscopy data.
+    - This model was trained on image data with Myosin VIIa stain, with a voxel size of 0.76 X 0.76 X 3.0 micrometer.
+
+It provides one detection model:
+- `Synapses`: for detecting afferent ribbon synapses in high-resolution isotropic light-sheet microscopy data.
+    - This model was trained on image data with CtBP2 stain, with a voxel size of 0.38 micrometer.
+
+**Note: If you want to run the segmentation in environments without internet access, you must download the models beforehand and transfer them for use at inference time.**
+
+The models can be downloaded from ownCloud:
+- [SGN](https://owncloud.gwdg.de/index.php/s/NZ2vv7hxX1imITG/download),
+- [IHC](https://owncloud.gwdg.de/index.php/s/wB7d2MjV5LRTP06/download),
+- [Synapses](https://owncloud.gwdg.de/index.php/s/A9W5NmOeBxiyZgY/download),
+- [SGN-lowres](https://owncloud.gwdg.de/index.php/s/OS7985CKaTTBT5g/download), and
+- [IHC-lowres](https://owncloud.gwdg.de/index.php/s/EhnV4brhpvFbSsy/download).
+
+Alternatively, after installation, the models can be downloaded using `flamingo_tools.download_model` for all or individual models:
+```bash
+# Download all models
+flamingo_tools.download_model
+# Download a single model
+flamingo_tools.download_model -m SGN
+```
 
 ## Usage
 
@@ -93,15 +125,6 @@ flamingo_tools.run_segmentation -i /path/to/data.tif -o /path/to/output_folder -
 ```
 Here, `-m` determines which model is used. See also [available models](#available-models).
 
-**Note: If you want to run the segmentation in environments without internet access, you must download the models beforehand and transfer them for use at inference time.**
-The models can be downloaded using `flamingo_tools.download_model` for all or individual models:
-```bash
-# Download all models
-flamingo_tools.download_model
-# Download a single model
-flamingo_tools.download_model -m SGN
-```
-
 To use a custom trained model you can use the argument `--checkpoint_path` (`-c`).
 
 `flamingo_tools.run_detection`: To detect synapses in volumetric light microscopy data. The command is used similarly to `flamingo_tools.run_segmentation`.
@@ -117,20 +140,3 @@ CochleaNet's functionality is implemented in the `flamingo_tools` python library
 - `flamingo_tools.mobie`: functionality to export flamingo image data or segmentation results to a MoBIE project.
 - `flamingo_tools.segmentation`: functionality to apply segmentation and detection models to large volumetric image data.
 - `flamingo_tools.training`: functionality to train segmentation and detection networks.
-
-
-## Available Models
-
-CochleaNet provides four different segmentation models:
-- `SGN`: for segmenting spiral ganglion neurons (SGNs) in high-resolution, isotropic light-sheet microscopy data.
-    - This model was trained on image data with parvalbumin (PV) stain, with a voxel size of 0.38 micrometer.
-- `IHC`: for segmenting inner hair cells (IHCs) in high-resolution, isotropic light-sheet microscopy data.
-    - This model was trained on image data with Vglut3 stain, with a voxel size of 0.38 micrometer.
-- `SGN-lowres`: for segmenting SGNs in lower-resolution, anisotropic light-sheet microscopy data.
-    - This model was trained on image data with PV stain, with a voxel size of 0.76 X 0.76 X 3.0 micrometer.
-- `IHC-lowres`: for segmenting IHCs in lower-resolution, anisotropic light-sheet microscopy data.
-    - This model was trained on image data with Myosin VIIa stain, with a voxel size of 0.76 X 0.76 X 3.0 micrometer.
-
-It provides one detection model:
-- `Synapses`: for detecting afferent ribbon synapses in high-resolution isotropic light-sheet microscopy data.
-    - This model was trained on image data with CtBP2 stain, with a voxel size of 0.38 micrometer.

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -14,7 +14,7 @@ In addition, it contains functionality for data pre-processing and different kin
 
 The networks and analysis methods were primarily developed for high-resolution isotropic data from a [custom light-sheet microscope](https://www.nature.com/articles/s41587-025-02882-8).
 The networks work best for the respective fluorescent stains they were trained on, but will work for similar stains.
-For example, we have successfully applied the network for SGN segmentation on a calretinin (CR) stain and the network for IHC segmentation on a Myosin VII A stain. 
+For example, we have successfully applied the network for SGN segmentation on a calretinin (CR) stain and the network for IHC segmentation on a Myosin VII A stain.
 In addition, CochleaNet provides networks for the segmentation of SGNs and IHCs in anisotropic data from a [commercial light-sheet microscope](https://www.miltenyibiotec.com/DE-en/products/macs-imaging-and-spatial-biology/ultramicroscope-platform.html).
 
 For more information on CochleaNet, check out our [preprint](https://doi.org/10.1101/2025.11.16.688700).
@@ -53,7 +53,7 @@ conda install -c conda-forge napari pyqt
 CochleaNet can be used via:
 - The [napari plugin](#napari-plugin): enables prediction with the pre-trained CochleaNet deep neural networks.
 - The [command line interface](#command-line-interface): enables data conversion, model prediction, and selected analysis workflows for large image data.
-- The [python library](#python-library): implements CochleaNet's functionality and can be used to implement flexible prediction and data analysis workflows for large image data. 
+- The [python library](#python-library): implements CochleaNet's functionality and can be used to implement flexible prediction and data analysis workflows for large image data.
 
 **Note: the napari plugin was not optimized for processing large data. Please use the CLI or python library for processing large data.**
 
@@ -92,6 +92,16 @@ Use `--file_ext .raw` if the data is stored in raw files. The the output data fo
 flamingo_tools.run_segmentation -i /path/to/data.tif -o /path/to/output_folder -m SGN
 ```
 Here, `-m` determines which model is used. See also [available models](#available-models).
+
+**Note: If you want to run the segmentation in environments without internet access, you must download the models beforehand and transfer them for use at inference time.**
+The models can be downloaded using `flamingo_tools.download_model` for all or individual models:
+```bash
+# Download all models
+flamingo_tools.download_model
+# Download a single model
+flamingo_tools.download_model -m SGN
+```
+
 To use a custom trained model you can use the argument `--checkpoint_path` (`-c`).
 
 `flamingo_tools.run_detection`: To detect synapses in volumetric light microscopy data. The command is used similarly to `flamingo_tools.run_segmentation`.

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -63,7 +63,7 @@ It provides one detection model:
 - `Synapses`: for detecting afferent ribbon synapses in high-resolution isotropic light-sheet microscopy data.
     - This model was trained on image data with CtBP2 stain, with a voxel size of 0.38 micrometer.
 
-**Note: If you want to run the segmentation in environments without internet access, you must download the models beforehand and transfer them for use at inference time.**
+**Note: If you want to run the segmentation in environments without internet access, you must download the models beforehand and transfer them for use at inference time. Transfer the models to the local cache directory, which can be identified by using flamingo_tools.info**
 
 The models can be downloaded from ownCloud:
 - [SGN](https://owncloud.gwdg.de/index.php/s/NZ2vv7hxX1imITG/download),
@@ -78,6 +78,11 @@ Alternatively, after installation, the models can be downloaded using `flamingo_
 flamingo_tools.download_model
 # Download a single model
 flamingo_tools.download_model -m SGN
+```
+
+They can be checked using
+```bash
+flamingo_tools.info
 ```
 
 ## Usage

--- a/flamingo_tools/info.py
+++ b/flamingo_tools/info.py
@@ -1,0 +1,36 @@
+import argparse
+import os
+import runpy
+
+from flamingo_tools.file_utils import get_cache_dir
+
+
+def module_info():
+    """Return information about the flamingo_tools module.
+
+    Checks if segmentation models are downloaded
+    Use this in environments where internet access is not available at inference time
+    (e.g. restricted HPC compute nodes). Run on a login node before submitting jobs.
+    """
+    parser = argparse.ArgumentParser(
+        description="Return information about the flamingo_tools module. "
+        "Check whether pre-trained CochleaNet models are in the local cache. "
+        "Run flamingo_tools.download_models to download models."
+    )
+    _ = parser.parse_args()
+
+    # Return version
+    version = runpy.run_path("flamingo_tools/version.py")["__version__"]
+    print(f"Version: {version}")
+
+    # Check downloaded models in cache directory
+    cache_dir = get_cache_dir()
+    model_dir = os.path.join(cache_dir, "models")
+    if not os.path.isdir(model_dir):
+        print(f"No models in cache directory {cache_dir}.")
+        print(f"Create model directory {model_dir} and transfer pre-trained models.")
+        print("If you have internet acces: Run flamingo_tools.download_models to download models.")
+    else:
+        downloaded_models = [entry.name for entry in os.scandir(model_dir)]
+        print(f"Model directory: {model_dir}")
+        print(f"Downloaded models: {downloaded_models}")

--- a/flamingo_tools/model_utils.py
+++ b/flamingo_tools/model_utils.py
@@ -1,12 +1,29 @@
 """Utility functionality for downloading CochleaNet models.
 """
 
+import argparse
 import os
 from typing import Dict, Optional, Union
 
 import pooch
 import torch
 from .file_utils import get_cache_dir
+
+MODEL_REGISTRY = {
+    "SGN": "3058690b49015d6210a8e8414eb341c34189fee660b8fac438f1fdc41bdfff98",
+    "IHC": "752dab7995b076ec4b8526b0539d1b33ade5de9251aaf6863d9bd8cc9cd036b6",
+    "Synapses": "2a42712b056f082b4794f15cf41b15678aab0bec1acc922ff9f0dc76abe6747e",
+    "SGN-lowres": "2c773792f0ef6022c7d052c452071cf7bf45dfce6b498b408ad6cd1cc3a30d35",
+    "IHC-lowres": "537f1d4afc5a582771b87adeccadfa5635e1defd13636702363992188ef5bdbd",
+}
+
+MODEL_URLS = {
+    "SGN": "https://owncloud.gwdg.de/index.php/s/NZ2vv7hxX1imITG/download",
+    "IHC": "https://owncloud.gwdg.de/index.php/s/wB7d2MjV5LRTP06/download",
+    "Synapses": "https://owncloud.gwdg.de/index.php/s/A9W5NmOeBxiyZgY/download",
+    "SGN-lowres": "https://owncloud.gwdg.de/index.php/s/OS7985CKaTTBT5g/download",
+    "IHC-lowres": "https://owncloud.gwdg.de/index.php/s/EhnV4brhpvFbSsy/download",
+}
 
 
 def _get_default_device():
@@ -57,31 +74,15 @@ def get_device(device: Optional[Union[str, torch.device]] = None) -> Union[str, 
 
 
 # FIXME: SGN-lowres seems to be the wrong model and doesn't work well on the sample data.
-def get_model_registry() -> None:
-    """Get the model registry for downloading pre-trained CochleaNet models.
-    """
-    registry = {
-        "SGN": "3058690b49015d6210a8e8414eb341c34189fee660b8fac438f1fdc41bdfff98",
-        "IHC": "752dab7995b076ec4b8526b0539d1b33ade5de9251aaf6863d9bd8cc9cd036b6",
-        "Synapses": "2a42712b056f082b4794f15cf41b15678aab0bec1acc922ff9f0dc76abe6747e",
-        "SGN-lowres": "2c773792f0ef6022c7d052c452071cf7bf45dfce6b498b408ad6cd1cc3a30d35",
-        "IHC-lowres": "537f1d4afc5a582771b87adeccadfa5635e1defd13636702363992188ef5bdbd",
-    }
-    urls = {
-        "SGN": "https://owncloud.gwdg.de/index.php/s/NZ2vv7hxX1imITG/download",
-        "IHC": "https://owncloud.gwdg.de/index.php/s/wB7d2MjV5LRTP06/download",
-        "Synapses": "https://owncloud.gwdg.de/index.php/s/A9W5NmOeBxiyZgY/download",
-        "SGN-lowres": "https://owncloud.gwdg.de/index.php/s/OS7985CKaTTBT5g/download",
-        "IHC-lowres": "https://owncloud.gwdg.de/index.php/s/EhnV4brhpvFbSsy/download",
-    }
+def get_model_registry() -> pooch.Pooch:
+    """Get the model registry for downloading pre-trained CochleaNet models."""
     cache_dir = get_cache_dir()
-    models = pooch.create(
+    return pooch.create(
         path=os.path.join(cache_dir, "models"),
         base_url="",
-        registry=registry,
-        urls=urls,
+        registry=MODEL_REGISTRY,
+        urls=MODEL_URLS,
     )
-    return models
 
 
 def get_model_path(model_type: str) -> str:
@@ -204,3 +205,30 @@ def get_default_tiling() -> Dict[str, Dict[str, int]]:
         print(f"Determining default tiling for CPU: {tiling}")
 
     return tiling
+
+
+def download_model():
+    """Download pre-trained CochleaNet models to the local cache.
+
+    Use this in environments where internet access is not available at inference time
+    (e.g. restricted HPC compute nodes). Run on a login node before submitting jobs.
+    """
+    all_models = list(MODEL_REGISTRY.keys())
+
+    parser = argparse.ArgumentParser(
+        description="Download pre-trained CochleaNet models to the local cache. "
+        "Run this on a machine with internet access before using 'flamingo_tools.run_segmentation' "
+        "or 'flamingo_tools.run_detection' on a node without internet access."
+    )
+    parser.add_argument(
+        "-m", "--model_type", nargs="+", choices=all_models, default=None,
+        help=f"The model(s) to download. Choose one or more of {all_models}. "
+        "Downloads all models if not specified.",
+    )
+    args = parser.parse_args()
+
+    model_types = args.model_type if args.model_type is not None else all_models
+    for model_type in model_types:
+        print(f"Downloading '{model_type}'...")
+        model_path = get_model_path(model_type)
+        print(f"  -> cached at: {model_path}")

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
             "flamingo_tools.convert_data = flamingo_tools.data_conversion:convert_lightsheet_to_bdv_cli",
             "flamingo_tools.run_segmentation = flamingo_tools.segmentation.cli:run_segmentation",
             "flamingo_tools.run_detection = flamingo_tools.segmentation.cli:run_detection",
+            "flamingo_tools.download_model = flamingo_tools.model_utils:download_model",
             "flamingo_tools.equidistant_centers = flamingo_tools.postprocessing.cli:equidistant_centers",
             "flamingo_tools.extract_block = flamingo_tools.postprocessing.cli:extract_block",
             "flamingo_tools.extract_central_blocks = flamingo_tools.postprocessing.cli:extract_central_blocks",

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
             "flamingo_tools.run_segmentation = flamingo_tools.segmentation.cli:run_segmentation",
             "flamingo_tools.run_detection = flamingo_tools.segmentation.cli:run_detection",
             "flamingo_tools.download_model = flamingo_tools.model_utils:download_model",
+            "flamingo_tools.info = flamingo_tools.info:module_info",
             "flamingo_tools.equidistant_centers = flamingo_tools.postprocessing.cli:equidistant_centers",
             "flamingo_tools.extract_block = flamingo_tools.postprocessing.cli:extract_block",
             "flamingo_tools.extract_central_blocks = flamingo_tools.postprocessing.cli:extract_central_blocks",


### PR DESCRIPTION
The goal of this branch is to add the ability to perform segmentation when there is no internet access.
The idea is to download the models in advance and use them at inference time.
This commit adds the CLI function `flamingo_tools.download_model` to download one or more models to the cache.

The question is whether to specify the download folder or change the usage `flamingo_tools.run_segmentation` which currently reads the model from the cache directory by default. This could be difficult if the models are transferred manually before evaluation. An alternative would be to provide the explicit model path to `flamingo_tools.run_segmentation`.  Napari widgets would need to be adapted as well, e.g. the DetectionWidget in `flamingo_tools/plugin/detection_widget.py`.

WIP