### PR TITLE
Add export script for micro-sam SGN v2 model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ converted/
 checkpoints/
 logs/
 *.csv
+
+# And some other files
+*.pt
+

--- a/development/export_micro_sam_sgn.py
+++ b/development/export_micro_sam_sgn.py
@@ -1,0 +1,35 @@
+import os
+import urllib.request
+
+from micro_sam.training.training import export_instance_segmentation_model
+
+
+OWNCLOUD_URL = "https://owncloud.gwdg.de/index.php/s/v8QBny7BOtwiHoM/download"
+MODEL_NAME = "cochlea_micro-sam_sgn-v2_2d"
+MODEL_TYPE = "vit_b_lm"
+
+
+def download_checkpoint(save_path):
+    if os.path.exists(save_path):
+        print(f"Checkpoint already at '{save_path}', skipping download.")
+        return
+    print("Downloading checkpoint ...")
+    urllib.request.urlretrieve(OWNCLOUD_URL, save_path)
+    print(f"Downloaded to '{save_path}'.")
+
+
+def main():
+    checkpoint_path = f"{MODEL_NAME}_checkpoint.pt"
+    output_path = f"{MODEL_NAME}.pt"
+
+    download_checkpoint(checkpoint_path)
+    export_instance_segmentation_model(checkpoint_path, output_path, model_type=MODEL_TYPE)
+
+    from micro_sam.instance_segmentation import get_predictor_and_decoder
+    print("Verifying model loads correctly ...")
+    get_predictor_and_decoder(model_type="vit_b", checkpoint_path=output_path)
+    print("Verification passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Hi @schilling40,

While debugging, I saw that your segmentation model was trained with `train_instance_segmentation` (UNETR-only), which requires `export_instance_segmentation_model` rather than `export_custom_sam_model`.

This script should work for you now! (subjected to a patch fix in https://github.com/computational-cell-analytics/micro-sam/pull/1200, which I'll merge in some)

And potentially closes https://github.com/computational-cell-analytics/cochlea-net/issues/102