### PR TITLE
Optional creation of accuracy dict during baseline evaluation

### DIFF
--- a/reproducibility/model_accuracy/IHC.json
+++ b/reproducibility/model_accuracy/IHC.json
@@ -1,0 +1,30 @@
+{
+	"cellpose3": {
+		"precision": 0.375,
+		"recall": 0.554,
+		"f1-score": 0.329,
+		"runtime": 162.349,
+		"runtime_std": 30.102
+	},
+	"cellpose-sam": {
+		"precision": 0.572,
+		"recall": 0.601,
+		"f1-score": 0.469,
+		"runtime": 2137.945,
+		"runtime_std": 304.285
+	},
+	"distance_unet_v4b": {
+		"precision": 0.693,
+		"recall": 0.567,
+		"f1-score": 0.618,
+		"runtime": 69.012,
+		"runtime_std": 73.538
+	},
+	"micro-sam": {
+		"precision": 0.053,
+		"recall": 0.684,
+		"f1-score": 0.094,
+		"runtime": 445.592,
+		"runtime_std": 106.585
+	}
+}

--- a/reproducibility/model_accuracy/SGN.json
+++ b/reproducibility/model_accuracy/SGN.json
@@ -1,0 +1,93 @@
+{
+	"spiner2D": {
+		"precision": 0.373,
+		"recall": 0.34,
+		"f1-score": 0.326,
+		"runtime": null,
+		"runtime_std": null
+	},
+	"cellpose3": {
+		"precision": 0.117,
+		"recall": 0.607,
+		"f1-score": 0.186,
+		"runtime": 167.912,
+		"runtime_std": 40.207
+	},
+	"cellpose3_finetuned": {
+		"precision": 0.581,
+		"recall": 0.727,
+		"f1-score": 0.621,
+		"runtime": 94.021,
+		"runtime_std": 23.098
+	},
+	"cellpose-sam": {
+		"precision": 0.218,
+		"recall": 0.723,
+		"f1-score": 0.313,
+		"runtime": 2232.008,
+		"runtime_std": 552.779
+	},
+	"distance_unet": {
+		"precision": 0.886,
+		"recall": 0.804,
+		"f1-score": 0.837,
+		"runtime": 168.835,
+		"runtime_std": 21.808
+	},
+	"distance_unet_f0": {
+		"precision": 0.887,
+		"recall": 0.807,
+		"f1-score": 0.839,
+		"runtime": 161.407,
+		"runtime_std": 20.783
+	},
+	"distance_unet_f1": {
+		"precision": 0.875,
+		"recall": 0.81,
+		"f1-score": 0.834,
+		"runtime": 158.267,
+		"runtime_std": 21.035
+	},
+	"distance_unet_f2": {
+		"precision": 0.827,
+		"recall": 0.855,
+		"f1-score": 0.834,
+		"runtime": 157.703,
+		"runtime_std": 20.492
+	},
+	"distance_unet_f3": {
+		"precision": 0.858,
+		"recall": 0.828,
+		"f1-score": 0.836,
+		"runtime": 157.753,
+		"runtime_std": 21.171
+	},
+	"distance_unet_f4": {
+		"precision": 0.876,
+		"recall": 0.808,
+		"f1-score": 0.833,
+		"runtime": 156.853,
+		"runtime_std": 21.1
+	},
+	"micro-sam": {
+		"precision": 0.14,
+		"recall": 0.782,
+		"f1-score": 0.228,
+		"runtime": 407.462,
+		"runtime_std": 107.494
+	},
+	"micro-sam_finetuned": {
+		"precision": 0.44,
+		"recall": 0.642,
+		"f1-score": 0.488,
+		"runtime": 789.582,
+		"runtime_std": 205.167
+	},
+	"stardist": {
+		"precision": 0.706,
+		"recall": 0.63,
+		"f1-score": 0.628,
+		"runtime": 536.52,
+		"runtime_std": 148.381
+	}
+}

--- a/scripts/baselines/eval_baseline.py
+++ b/scripts/baselines/eval_baseline.py
@@ -1,5 +1,6 @@
 import os
 import json
+import argparse
 
 import imageio.v3 as imageio
 import numpy as np
@@ -236,6 +237,75 @@ def eval_segmentation_spiner(
         json.dump(seg_dicts, f, indent='\t', separators=(',', ': '))
 
 
+def compute_accuracy(eval_dir: str) -> dict:
+    """Compute average precision, recall, F1-score, and runtime from per-crop dictionaries.
+
+    Args:
+        eval_dir: Directory containing per-crop *_dic.json files.
+
+    Returns:
+        Dict with keys 'precision', 'recall', 'f1-score', 'runtime', 'runtime_std'.
+    """
+    eval_dicts = [entry.path for entry in os.scandir(eval_dir) if entry.is_file() and "dic.json" in entry.path]
+    precision_list, recall_list, f1_list, time_list = [], [], [], []
+    for eval_dic in eval_dicts:
+        with open(eval_dic, "r") as f:
+            d = json.load(f)
+        tp = len(d["tp_objects"])
+        fp = len(d["fp"])
+        fn = len(d["fn"])
+
+        precision = tp / (tp + fp) if tp + fp != 0 else 0
+        recall = tp / (tp + fn) if tp + fn != 0 else 0
+        f1 = 2 * precision * recall / (precision + recall) if precision + recall != 0 else 0
+
+        precision_list.append(precision)
+        recall_list.append(recall)
+        f1_list.append(f1)
+        if d["time"] is not None:
+            time_list.append(d["time"])
+
+    runtime_mean = float(np.mean(time_list)) if time_list else None
+    runtime_std = float(np.std(time_list)) if time_list else None
+
+    return {
+        "precision": round(float(np.mean(precision_list)), 3),
+        "recall": round(float(np.mean(recall_list)), 3),
+        "f1-score": round(float(np.mean(f1_list)), 3),
+        "runtime": round(runtime_mean, 3) if runtime_mean is not None else None,
+        "runtime_std": round(runtime_std, 3) if runtime_std is not None else None,
+    }
+
+
+def save_accuracy_json(
+    segm_type: str,
+    baselines: list[str],
+    seg_dir: str,
+    output_dir: str,
+) -> None:
+    """Compute and save accuracy metrics for all baselines to a JSON file.
+
+    Args:
+        segm_type: Segmentation type, 'SGN' or 'IHC'.
+        baseline_keys: Mapping from baseline directory name to plot key.
+        seg_dir: Directory containing per-baseline subdirectories.
+        output_dir: Output directory for the JSON file.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    result = {}
+    for baseline in baselines:
+        baseline_dir = os.path.join(seg_dir, baseline)
+        if not os.path.isdir(baseline_dir):
+            print(f"Warning: {baseline_dir} not found, skipping.")
+            continue
+        result[baseline] = compute_accuracy(baseline_dir)
+
+    out_path = os.path.join(output_dir, f"{segm_type}.json")
+    with open(out_path, "w") as f:
+        json.dump(result, f, indent="\t", separators=(",", ": "))
+    print(f"Saved accuracy metrics to {out_path}")
+
+
 def print_accuracy(
     eval_dir: str,
 ) -> None:
@@ -379,6 +449,13 @@ def runtimes_ihc(
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Evaluate baseline segmentation methods.")
+    parser.add_argument(
+        "--output_dir", "-o", type=str, default=None,
+        help="Optional directory to save accuracy JSON files (e.g. flamingo_tools/reproducibility/model_accuracy).",
+    )
+    args = parser.parse_args()
+
     eval_all_sgn()
     eval_all_ihc()
     print_accuracy_sgn()
@@ -391,6 +468,12 @@ def main():
     print()
     print("IHCs:")
     runtimes_ihc()
+
+    if args.output_dir is not None:
+        sgn_seg_dir = os.path.join(COCHLEA_DIR, "predictions/val_sgn")
+        ihc_seg_dir = os.path.join(COCHLEA_DIR, "predictions/val_ihc")
+        save_accuracy_json("SGN", SGN_BASELINES, sgn_seg_dir, args.output_dir)
+        save_accuracy_json("IHC", IHC_BASELINES, ihc_seg_dir, args.output_dir)
 
 
 if __name__ == "__main__":

--- a/scripts/figures/plot_supp_fig2.py
+++ b/scripts/figures/plot_supp_fig2.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 
 import numpy as np
@@ -14,6 +15,27 @@ COLOR_P = "#9C5027"
 COLOR_R = "#67279C"
 COLOR_F = "#9C276F"
 COLOR_T = "#279C52"
+
+# Plotting metadata (label and marker) per segmentation type and baseline key.
+# Key order determines the left-to-right order on the x-axis.
+PLOT_METADATA = {
+    "SGN": {
+        "stardist": {"label": "Stardist", "marker": "*"},
+        "micro-sam": {"label": "µSAM", "marker": "D"},
+        "micro-sam_finetuned": {"label": "µSAM finetuned", "marker": "D"},
+        "cellpose3": {"label": "Cellpose 3", "marker": "v"},
+        "cellpose3_finetuned": {"label": "Cellpose 3 finetuned", "marker": "v"},
+        "cellpose-sam": {"label": "Cellpose-SAM", "marker": "^"},
+        "spiner2D": {"label": "Spiner", "marker": "o"},
+        "distance_unet": {"label": "CochleaNet", "marker": "s"},
+    },
+    "IHC": {
+        "micro-sam": {"label": "µSAM", "marker": "D"},
+        "cellpose3": {"label": "Cellpose 3", "marker": "v"},
+        "cellpose-sam": {"label": "Cellpose-SAM", "marker": "^"},
+        "distance_unet": {"label": "CochleaNet", "marker": "s"},
+    },
+}
 
 
 def plot_legend_supp_fig02(save_path):
@@ -38,6 +60,7 @@ def supp_fig_02(
     plot: bool = False,
     segm: str = "SGN",
     mode: str = "precision",
+    data_dir: str = None,
 ):
     """Plot panels for Supplementary Figure 2.
 
@@ -46,128 +69,28 @@ def supp_fig_02(
         plot:
         segm: Segmentation type. Either "SGN" or "IHC".
         mode: Mode for plotting. Either "precision" or "runtime".
+        data_dir: Directory containing SGN.json and IHC.json accuracy files produced by
+            eval_baseline.py. When provided, metrics are loaded from these files instead of
+            the hardcoded fallback values.
     """
-    # SGN
-    value_dict = {
-        "SGN": {
-            "stardist": {
-                "label": "Stardist",
-                "precision": 0.706,
-                "recall": 0.630,
-                "f1-score": 0.628,
-                "marker": "*",
-                "runtime": 536.5,
-                "runtime_std": 148.4
-            },
-            "micro_sam": {
-                "label": "µSAM",
-                "precision": 0.140,
-                "recall": 0.782,
-                "f1-score": 0.228,
-                "marker": "D",
-                "runtime": 407.5,
-                "runtime_std": 107.5
-            },
-            "micro_sam_finetuned": {
-                "label": "µSAM finetuned",
-                "precision": 0.440,
-                "recall": 0.642,
-                "f1-score": 0.488,
-                "marker": "D",
-                "runtime": 789.582,
-                "runtime_std": 205.166
-            },
-            "cellpose_3": {
-                "label": "Cellpose 3",
-                "precision": 0.117,
-                "recall": 0.607,
-                "f1-score": 0.186,
-                "marker": "v",
-                "runtime": 167.9116359,
-                "runtime_std": 40.2,
-            },
-            "cellpose_3_finetuned": {
-                "label": "Cellpose 3 finetuned",
-                "precision": 0.581,
-                "recall": 0.727,
-                "f1-score": 0.621,
-                "marker": "v",
-                "runtime": 94.021,
-                "runtime_std": 23.098,
-            },
-            "cellpose_sam": {
-                "label": "Cellpose-SAM",
-                "precision": 0.250,
-                "recall": 0.003,
-                "f1-score": 0.005,
-                "marker": "^",
-                "runtime": 2232.007748,
-                "runtime_std": None,
-            },
-            "spiner2D": {
-                "label": "Spiner",
-                "precision": 0.373,
-                "recall": 0.340,
-                "f1-score": 0.326,
-                "marker": "o",
-                "runtime": None,
-                "runtime_std": None,
-            },
-            "distance_unet": {
-                "label": "CochleaNet",
-                "precision": 0.886,
-                "recall": 0.804,
-                "f1-score": 0.837,
-                "marker": "s",
-                "runtime": 168.8,
-                "runtime_std": 21.8
-            },
-        },
-        "IHC": {
-            "micro_sam": {
-                "label": "µSAM",
-                "precision": 0.053,
-                "recall": 0.684,
-                "f1-score": 0.094,
-                "marker": "D",
-                "runtime": 445.6,
-                "runtime_std": 106.6
-            },
-            "cellpose_3": {
-                "label": "Cellpose 3",
-                "precision": 0.375,
-                "recall": 0.554,
-                "f1-score": 0.329,
-                "marker": "v",
-                "runtime": 162.3493934,
-                "runtime_std": 30.1,
-            },
-            "cellpose_sam": {
-                "label": "Cellpose-SAM",
-                "precision": 0.636,
-                "recall": 0.025,
-                "f1-score": 0.047,
-                "marker": "^",
-                "runtime": 2137.944779,
-                "runtime_std": None
-            },
-            "distance_unet": {
-                "label": "CochleaNet",
-                "precision": 0.693,
-                "recall": 0.567,
-                "f1-score": 0.618,
-                "marker": "s",
-                "runtime": 69.01,
-                "runtime_std": None
-            },
-        }
-    }
+    if data_dir is not None:
+        json_path = os.path.join(data_dir, f"{segm}.json")
+        with open(json_path, "r") as f:
+            metrics = json.load(f)
+        segm_dict = {}
+        for key, meta in PLOT_METADATA[segm].items():
+            if key not in metrics:
+                continue
+            segm_dict[key] = {"label": meta["label"], "marker": meta["marker"], **metrics[key]}
+        value_dict = {segm: segm_dict}
+    else:
+        raise ValueError("Please provide a data directory containing accuracy values.")
 
     # Convert setting labels to numerical x positions
     offset = 0.08  # horizontal shift for scatter separation
 
     # Plot
-    tick_rotation = 0
+    tick_rotation = 45
 
     main_label_size = 20
     main_tick_size = 16
@@ -250,18 +173,31 @@ def main():
     parser.add_argument("--figure_dir", "-f", type=str, help="Output directory for plots.",
                         default="./panels/supp_fig2")
     parser.add_argument("--plot", action="store_true")
+    _default_data_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "reproducibility", "model_accuracy",
+    )
+    parser.add_argument(
+        "--data_dir", "-d", type=str, default=_default_data_dir,
+        help="Directory containing SGN.json and IHC.json accuracy files. "
+             f"Defaults to {_default_data_dir}.",
+    )
     args = parser.parse_args()
 
     os.makedirs(args.figure_dir, exist_ok=True)
 
+    data_dir = args.data_dir if os.path.isdir(args.data_dir) else None
+
     # Supplementary Figure 2: Comparing other methods in terms of segmentation accuracy and runtime
     plot_legend_supp_fig02(save_path=os.path.join(args.figure_dir, f"supp_fig_02_legend_colors.{FILE_EXTENSION}"))
-    supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02a_sgn_accuracy.{FILE_EXTENSION}"), segm="SGN")
-    supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02b_ihc_accuracy.{FILE_EXTENSION}"), segm="IHC")
+    supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02a_sgn_accuracy.{FILE_EXTENSION}"),
+                segm="SGN", data_dir=data_dir)
+    supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02b_ihc_accuracy.{FILE_EXTENSION}"),
+                segm="IHC", data_dir=data_dir)
     supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02a_sgn_time.{FILE_EXTENSION}"),
-                segm="SGN", mode="runtime")
+                segm="SGN", mode="runtime", data_dir=data_dir)
     supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02b_ihc_time.{FILE_EXTENSION}"),
-                segm="IHC", mode="runtime")
+                segm="IHC", mode="runtime", data_dir=data_dir)
 
 
 if __name__ == "__main__":

--- a/scripts/figures/plot_supp_fig2.py
+++ b/scripts/figures/plot_supp_fig2.py
@@ -61,6 +61,7 @@ def supp_fig_02(
     segm: str = "SGN",
     mode: str = "precision",
     data_dir: str = None,
+    use_folds: bool = False,
 ):
     """Plot panels for Supplementary Figure 2.
 
@@ -72,10 +73,29 @@ def supp_fig_02(
         data_dir: Directory containing SGN.json and IHC.json accuracy files produced by
             eval_baseline.py. When provided, metrics are loaded from these files instead of
             the hardcoded fallback values.
+        use_folds: If True, replace the direct distance_unet value with the mean and standard
+            deviation computed across all cross-validation fold variants (keys matching
+            '<base>_f<digit>') found in the JSON. Applies to any key that has fold variants.
     """
     json_path = os.path.join(data_dir, f"{segm}.json")
     with open(json_path, "r") as f:
         metrics = json.load(f)
+
+    # Pre-compute fold mean ± std for any key that has fold variants in the JSON.
+    fold_stats = {}
+    if use_folds:
+        for key in PLOT_METADATA[segm]:
+            fold_keys = [k for k in metrics if k.startswith(f"{key}_f") and k[len(key) + 2:].isdigit()]
+            if not fold_keys:
+                continue
+            fs = {}
+            for metric in ("precision", "recall", "f1-score"):
+                vals = [metrics[k][metric] for k in fold_keys]
+                fs[metric] = (float(np.mean(vals)), float(np.std(vals)))
+            rt_vals = [metrics[k]["runtime"] for k in fold_keys if metrics[k]["runtime"] is not None]
+            fs["runtime"] = (float(np.mean(rt_vals)), float(np.std(rt_vals))) if rt_vals else (None, None)
+            fold_stats[key] = fs
+
     segm_dict = {}
     for key, meta in PLOT_METADATA[segm].items():
         if key not in metrics:
@@ -92,26 +112,39 @@ def supp_fig_02(
     main_label_size = 20
     main_tick_size = 16
     marker_size = 200
+    capsize = 4
 
     labels = [value_dict[segm][key]["label"] for key in value_dict[segm].keys()]
 
     if mode == "precision":
         fig, ax = plt.subplots(figsize=(10, 5))
-        # Convert setting labels to numerical x positions
-        offset = 0.08  # horizontal shift for scatter separation
+        offset = 0.08
         for num, key in enumerate(list(value_dict[segm].keys())):
-            precision = [value_dict[segm][key]["precision"]]
-            recall = [value_dict[segm][key]["recall"]]
-            f1score = [value_dict[segm][key]["f1-score"]]
             marker = value_dict[segm][key]["marker"]
             x_pos = num + 1
 
-            plt.scatter([x_pos - offset], precision, label="Precision manual",
-                        color=COLOR_P, marker=marker, s=marker_size)
-            plt.scatter([x_pos], recall, label="Recall manual",
-                        color=COLOR_R, marker=marker, s=marker_size)
-            plt.scatter([x_pos + offset], f1score, label="F1-score manual",
-                        color=COLOR_F, marker=marker, s=marker_size)
+            if use_folds and key in fold_stats:
+                precision, precision_std = fold_stats[key]["precision"]
+                recall, recall_std = fold_stats[key]["recall"]
+                f1score, f1score_std = fold_stats[key]["f1-score"]
+            else:
+                precision = value_dict[segm][key]["precision"]
+                recall = value_dict[segm][key]["recall"]
+                f1score = value_dict[segm][key]["f1-score"]
+                precision_std = recall_std = f1score_std = None
+
+            plt.scatter([x_pos - offset], [precision], color=COLOR_P, marker=marker, s=marker_size)
+            if precision_std is not None:
+                plt.errorbar([x_pos - offset], [precision], yerr=[precision_std],
+                             fmt="none", color="black", capsize=capsize)
+            plt.scatter([x_pos], [recall], color=COLOR_R, marker=marker, s=marker_size)
+            if recall_std is not None:
+                plt.errorbar([x_pos], [recall], yerr=[recall_std],
+                             fmt="none", color="black", capsize=capsize)
+            plt.scatter([x_pos + offset], [f1score], color=COLOR_F, marker=marker, s=marker_size)
+            if f1score_std is not None:
+                plt.errorbar([x_pos + offset], [f1score], yerr=[f1score_std],
+                             fmt="none", color="black", capsize=capsize)
 
         # Labels and formatting
         x_pos = np.arange(1, len(labels) + 1)
@@ -119,7 +152,6 @@ def supp_fig_02(
         plt.yticks(fontsize=main_tick_size)
         plt.ylabel("Value", fontsize=main_label_size)
         plt.ylim(-0.1, 1)
-        # plt.legend(loc="lower right", fontsize=legendsize)
         plt.grid(axis="y", linestyle="solid", alpha=0.5)
 
     elif mode == "runtime":
@@ -127,16 +159,21 @@ def supp_fig_02(
         if "Spiner" in labels:
             labels.remove("Spiner")
 
-        # Convert setting labels to numerical x positions
-        offset = 0.08  # horizontal shift for scatter separation
         x_pos = 1
         for num, key in enumerate(list(value_dict[segm].keys())):
-            runtime = [value_dict[segm][key]["runtime"]]
-            if runtime[0] is None:
+            if use_folds and key in fold_stats:
+                runtime, runtime_std = fold_stats[key]["runtime"]
+            else:
+                runtime = value_dict[segm][key]["runtime"]
+                runtime_std = None
+            if runtime is None:
                 continue
             marker = value_dict[segm][key]["marker"]
-            plt.scatter([x_pos], runtime, label="Runtime", color=COLOR_T, marker=marker, s=marker_size)
-            x_pos = x_pos + 1
+            plt.scatter([x_pos], [runtime], color=COLOR_T, marker=marker, s=marker_size)
+            if runtime_std is not None:
+                plt.errorbar([x_pos], [runtime], yerr=[runtime_std],
+                             fmt="none", color="black", capsize=capsize)
+            x_pos += 1
 
         # Labels and formatting
         x_pos = np.arange(1, len(labels) + 1)
@@ -145,7 +182,6 @@ def supp_fig_02(
         plt.ylabel("Processing time [s]", fontsize=main_label_size)
         plt.ylim(10, 2600)
         plt.yscale('log')
-        # plt.legend(loc="lower right", fontsize=legendsize)
         plt.grid(axis="y", linestyle="solid", alpha=0.5)
 
     else:
@@ -247,6 +283,10 @@ def main():
     parser.add_argument("--figure_dir", "-f", type=str, help="Output directory for plots.",
                         default="./panels/supp_fig2")
     parser.add_argument("--plot", action="store_true")
+    parser.add_argument(
+        "--use_folds", action="store_true",
+        help="Replace the CochleaNet point with the mean ± std across the five cross-validation folds.",
+    )
     _default_data_dir = os.path.join(
         os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
         "reproducibility", "model_accuracy",
@@ -266,13 +306,13 @@ def main():
     plot_legend_supp_fig02(save_path=os.path.join(args.figure_dir, f"supp_fig_02_legend_colors.{FILE_EXTENSION}"))
     if data_dir is not None:
         supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02a_sgn_accuracy.{FILE_EXTENSION}"),
-                    segm="SGN", data_dir=data_dir)
+                    segm="SGN", data_dir=data_dir, use_folds=args.use_folds)
         supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02b_ihc_accuracy.{FILE_EXTENSION}"),
-                    segm="IHC", data_dir=data_dir)
+                    segm="IHC", data_dir=data_dir, use_folds=args.use_folds)
         supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02a_sgn_time.{FILE_EXTENSION}"),
-                    segm="SGN", mode="runtime", data_dir=data_dir)
+                    segm="SGN", mode="runtime", data_dir=data_dir, use_folds=args.use_folds)
         supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02b_ihc_time.{FILE_EXTENSION}"),
-                    segm="IHC", mode="runtime", data_dir=data_dir)
+                    segm="IHC", mode="runtime", data_dir=data_dir, use_folds=args.use_folds)
         plot_fold_accuracy(
             save_path=os.path.join(args.figure_dir, f"supp_fig_sgn_folds.{FILE_EXTENSION}"),
             data_dir=data_dir,

--- a/scripts/figures/plot_supp_fig2.py
+++ b/scripts/figures/plot_supp_fig2.py
@@ -73,18 +73,15 @@ def supp_fig_02(
             eval_baseline.py. When provided, metrics are loaded from these files instead of
             the hardcoded fallback values.
     """
-    if data_dir is not None:
-        json_path = os.path.join(data_dir, f"{segm}.json")
-        with open(json_path, "r") as f:
-            metrics = json.load(f)
-        segm_dict = {}
-        for key, meta in PLOT_METADATA[segm].items():
-            if key not in metrics:
-                continue
-            segm_dict[key] = {"label": meta["label"], "marker": meta["marker"], **metrics[key]}
-        value_dict = {segm: segm_dict}
-    else:
-        raise ValueError("Please provide a data directory containing accuracy values.")
+    json_path = os.path.join(data_dir, f"{segm}.json")
+    with open(json_path, "r") as f:
+        metrics = json.load(f)
+    segm_dict = {}
+    for key, meta in PLOT_METADATA[segm].items():
+        if key not in metrics:
+            continue
+        segm_dict[key] = {"label": meta["label"], "marker": meta["marker"], **metrics[key]}
+    value_dict = {segm: segm_dict}
 
     # Convert setting labels to numerical x positions
     offset = 0.08  # horizontal shift for scatter separation
@@ -168,6 +165,83 @@ def supp_fig_02(
         plt.close()
 
 
+def plot_fold_accuracy(
+    save_path: str,
+    data_dir: str = None,
+    plot: bool = False,
+):
+    """Plot precision, recall, F1-score, and processing time per cross-validation fold.
+
+    Reads fold entries (keys matching 'distance_unet_f*') from SGN.json and plots all four
+    metrics in one figure: precision, recall, and F1-score on the left y-axis; processing
+    time on a log-scale right y-axis.
+
+    Args:
+        save_path: Path for saving figure.
+        data_dir: Directory containing SGN.json produced by eval_baseline.py.
+        plot: Whether to display the plot interactively.
+    """
+    if data_dir is None:
+        raise ValueError("Please provide a data directory containing SGN.json.")
+
+    json_path = os.path.join(data_dir, "SGN.json")
+    with open(json_path, "r") as f:
+        metrics = json.load(f)
+
+    fold_keys = sorted(k for k in metrics if k.startswith("distance_unet_f"))
+    labels = [k.replace("distance_unet_f", "Fold ") for k in fold_keys]
+    x_positions = np.arange(1, len(fold_keys) + 1)
+
+    marker = "s"
+    marker_size = 200
+    main_label_size = 20
+    main_tick_size = 16
+    offset = 0.08
+
+    fig, ax1 = plt.subplots(figsize=(8, 5))
+    ax2 = ax1.twinx()
+
+    for i, key in enumerate(fold_keys):
+        d = metrics[key]
+        x = x_positions[i]
+        ax1.scatter([x - offset], [d["precision"]], color=COLOR_P, marker=marker, s=marker_size)
+        ax1.scatter([x], [d["recall"]], color=COLOR_R, marker=marker, s=marker_size)
+        ax1.scatter([x + offset], [d["f1-score"]], color=COLOR_F, marker=marker, s=marker_size)
+        if d["runtime"] is not None:
+            ax2.scatter([x], [d["runtime"]], color=COLOR_T, marker=marker, s=marker_size)
+
+    ax1.set_xticks(x_positions)
+    ax1.set_xticklabels(labels, fontsize=main_tick_size)
+    ax1.set_ylim(-0.1, 1)
+    ax1.set_ylabel("Value", fontsize=main_label_size)
+    ax1.tick_params(axis="y", labelsize=main_tick_size)
+    # ax1.grid(axis="y", linestyle="solid", alpha=0.5)
+
+    ax2.set_ylabel("Processing time [s]", fontsize=main_label_size, color=COLOR_T)
+    ax2.set_ylim(95, 200)
+    # ax2.set_yscale("log")
+    ax2.tick_params(axis="y", labelsize=main_tick_size, labelcolor=COLOR_T)
+
+    color = [COLOR_P, COLOR_R, COLOR_F, COLOR_T]
+    label = ["Precision", "Recall", "F1-score", "Processing time"]
+
+    handles = [get_flatline_handle(c) for c in color]
+    plt.legend(handles, label, loc=(0, 1), ncol=len(label), framealpha=1, frameon=False)
+
+    plt.tight_layout()
+    prism_cleanup_axes(ax1)
+
+    if ".png" in save_path:
+        plt.savefig(save_path, bbox_inches="tight", pad_inches=0.1, dpi=png_dpi)
+    else:
+        plt.savefig(save_path, bbox_inches="tight", pad_inches=0)
+
+    if plot:
+        plt.show()
+    else:
+        plt.close()
+
+
 def main():
     parser = argparse.ArgumentParser(description="Generate plots for Supplementary Fig 2 of the cochlea paper.")
     parser.add_argument("--figure_dir", "-f", type=str, help="Output directory for plots.",
@@ -190,14 +264,22 @@ def main():
 
     # Supplementary Figure 2: Comparing other methods in terms of segmentation accuracy and runtime
     plot_legend_supp_fig02(save_path=os.path.join(args.figure_dir, f"supp_fig_02_legend_colors.{FILE_EXTENSION}"))
-    supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02a_sgn_accuracy.{FILE_EXTENSION}"),
-                segm="SGN", data_dir=data_dir)
-    supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02b_ihc_accuracy.{FILE_EXTENSION}"),
-                segm="IHC", data_dir=data_dir)
-    supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02a_sgn_time.{FILE_EXTENSION}"),
-                segm="SGN", mode="runtime", data_dir=data_dir)
-    supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02b_ihc_time.{FILE_EXTENSION}"),
-                segm="IHC", mode="runtime", data_dir=data_dir)
+    if data_dir is not None:
+        supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02a_sgn_accuracy.{FILE_EXTENSION}"),
+                    segm="SGN", data_dir=data_dir)
+        supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02b_ihc_accuracy.{FILE_EXTENSION}"),
+                    segm="IHC", data_dir=data_dir)
+        supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02a_sgn_time.{FILE_EXTENSION}"),
+                    segm="SGN", mode="runtime", data_dir=data_dir)
+        supp_fig_02(save_path=os.path.join(args.figure_dir, f"supp_fig_02b_ihc_time.{FILE_EXTENSION}"),
+                    segm="IHC", mode="runtime", data_dir=data_dir)
+        plot_fold_accuracy(
+            save_path=os.path.join(args.figure_dir, f"supp_fig_sgn_folds.{FILE_EXTENSION}"),
+            data_dir=data_dir,
+            plot=args.plot,
+        )
+    else:
+        raise ValueError("Please provide a data directory containing dictionaries produced by eval_baseline.py")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Create accuracy dictionaries to evaluate baseline models

`eval_baseline.py`
- Added `compute_accuracy(eval_dir)` — reads all `*_dic.json` files in a baseline directory and returns `{precision, recall, f1-score, runtime, runtime_std}` as rounded floats.
- Added `save_accuracy_json(segm_type, baseline_keys, seg_dir, output_dir)` — iterates over the key mapping, calls `compute_accuracy()` per baseline, and writes `SGN.json` or `IHC.json` to the output dir.
- Updated `main()` with an `--output_dir` (`-o`) argument; when given, saves both JSON files after the existing print output.

`plot_supp_fig2.py`:
- Added `import json`.
- Extracted `PLOT_METADATA` — a constant dict holding the `label` and `marker` per baseline key, in the correct x-axis order, for both SGN and IHC.
- `supp_fig_02()` gains a `data_dir` parameter. When set, it loads the JSON file and merges metrics with `PLOT_METADATA` to build `value_dict`;
- removed hardcoded values.
- `main()` gains a `--data_dir` (`-d`) argument defaulting to `reproducibility/model_accuracy/` (resolved relative to the script file). If that directory doesn't exist yet, `data_dir=None` is passed and the plotting fails.

**Usage**:
```bash
# Evaluate and save JSON to the reproducibility archive
python scripts/baselines/eval_baseline.py -o flamingo_tools/reproducibility/model_accuracy

# Plot using the archived JSON (automatic when directory exists)
python scripts/figures/plot_supp_fig2.py
```