### PR TITLE
Introduce HeatMapFlowTransform

### DIFF
--- a/flamingo_tools/segmentation/synapse_detection.py
+++ b/flamingo_tools/segmentation/synapse_detection.py
@@ -315,7 +315,8 @@ def marker_detection(
 
     if not os.path.exists(detection_path):
         synapse_detection_from_prediction(output_path, detection_path,
-                                          prediction_key=prediction_key, voxel_size=voxel_size)
+                                          prediction_key=prediction_key, voxel_size=voxel_size,
+                                          model_path=model_path)
 
     else:
         with open(detection_path, "r") as f:

--- a/flamingo_tools/segmentation/synapse_detection.py
+++ b/flamingo_tools/segmentation/synapse_detection.py
@@ -1,15 +1,77 @@
 import os
+import warnings
 from typing import Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
+import torch
 import zarr
 from scipy.ndimage import binary_dilation
 
 from elf.parallel.local_maxima import find_local_maxima
 from elf.parallel.distance_transform import map_points_to_objects
 from flamingo_tools.file_utils import read_image_data
-from flamingo_tools.segmentation.unet_prediction import prediction_impl
+from flamingo_tools.segmentation.unet_prediction import prediction_impl, SelectChannel
+
+# Must match the sigma used in CsvHeatmapFlowTransform during training.
+_HEATMAP_FLOW_SIGMA = 1
+
+
+def _get_model_out_channels(model_path):
+    """Return the number of output channels of a model file or trainer checkpoint."""
+    try:
+        import sys
+        import flamingo_tools.synapse_detection.detection_dataset as _dd
+        sys.modules.setdefault("detection_dataset", _dd)
+    except ImportError:
+        pass
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        obj = torch.load(model_path, map_location="cpu", weights_only=False)
+    if isinstance(obj, dict) and "model_state" in obj:
+        return obj["init"]["model_kwargs"].get("out_channels", 1)
+    return obj.state_dict()["out_conv.bias"].shape[0]
+
+
+def _flow_corrected_detections(pred, min_distance, threshold_abs, block_shape, n_threads):
+    """Detect peaks and refine their positions using stereographic flow channels.
+
+    Args:
+        pred: Zarr/array of shape (Z, Y, X) for single-channel models or
+              (5, Z, Y, X) for heatmap+flow models.
+        min_distance: Minimum distance between detected peaks in voxels.
+        threshold_abs: Absolute heatmap threshold for peak detection.
+        block_shape: Spatial block shape for parallel peak detection.
+        n_threads: Number of threads.
+
+    Returns:
+        (N, 3) float array of [z, y, x] coordinates (sub-voxel if flow applied).
+    """
+    have_flow = pred.ndim == 4 and pred.shape[0] >= 5
+    # SelectChannel presents the 4-D (C, Z, Y, X) zarr as a 3-D (Z, Y, X) view
+    # so find_local_maxima can work out-of-core without loading the full volume.
+    heatmap = SelectChannel(pred, 0) if have_flow else pred
+
+    peak_coords = find_local_maxima(
+        heatmap, block_shape=block_shape, min_distance=min_distance,
+        threshold_abs=threshold_abs, verbose=True, n_threads=n_threads,
+    )
+
+    if not have_flow or len(peak_coords) == 0:
+        return peak_coords.astype(float)
+
+    s = _HEATMAP_FLOW_SIGMA
+    adjusted = np.empty((len(peak_coords), 3), dtype=float)
+    for i, (z, y, x) in enumerate(peak_coords):
+        zi, yi, xi = int(z), int(y), int(x)
+        w  = float(pred[1, zi, yi, xi])
+        vz = float(pred[2, zi, yi, xi])
+        vy = float(pred[3, zi, yi, xi])
+        vx = float(pred[4, zi, yi, xi])
+        denom = 1.0 + w + 1e-8
+        adjusted[i] = [z + s * vz / denom, y + s * vy / denom, x + s * vx / denom]
+
+    return adjusted
 
 
 def map_and_filter_detections(
@@ -72,6 +134,50 @@ def map_and_filter_detections(
     return detections
 
 
+def synapse_detection_from_prediction(
+    prediction_path: str,
+    detection_path: str,
+    block_shape: Optional[Tuple[int, int, int]] = None,
+    prediction_key: str = "prediction",
+    voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
+    force_overwrite: bool = False,
+):
+    """Run synapse detection for prediction.
+
+    Args:
+        prediction_path: Input path to synapse prediction in ZARR format.
+        detection_path: Output path for synapse detection.
+        block_shape: The block-shape for running the prediction.
+        prediction_key: Input key for prediction.
+        voxel_size: The voxel size of the data in micrometer.
+        force_overwrite: Forcefully overwrite output detection.
+    """
+
+    if not os.path.exists(detection_path) and not force_overwrite:
+        pred = zarr.open(prediction_path, "r")[prediction_key]
+        # Use spatial chunk shape (drop leading channel dim for multi-channel predictions).
+        det_block_shape = block_shape or tuple(pred.chunks[-3:])
+        detections = _flow_corrected_detections(
+            pred, min_distance=2, threshold_abs=0.5,
+            block_shape=det_block_shape, n_threads=16,
+        )
+        # Save the result in MoBIE compatible format.
+        detections = np.concatenate(
+            [np.arange(1, len(detections) + 1)[:, None], detections[:, ::-1]], axis=1
+        )
+        detections = pd.DataFrame(detections, columns=["spot_id", "x", "y", "z"])
+
+        # scale coordinates
+        detections["x"] *= voxel_size[0]
+        detections["y"] *= voxel_size[1]
+        detections["z"] *= voxel_size[2]
+
+        detections.to_csv(detection_path, index=False, sep="\t")
+    else:
+        print(f"Skipping peak detection. {detection_path} already exists.")
+
+
+
 def run_prediction(
     input_path: str,
     input_key: str,
@@ -101,30 +207,20 @@ def run_prediction(
         skip_prediction = True
 
     if not skip_prediction:
+        out_channels = _get_model_out_channels(model_path)
         prediction_impl(
             input_path, input_key, output_folder, model_path,
             scale=None, block_shape=block_shape, halo=halo,
-            apply_postprocessing=False, output_channels=1,
+            apply_postprocessing=False, output_channels=out_channels,
         )
 
     detection_path = os.path.join(output_folder, "synapse_detection.tsv")
-    if not os.path.exists(detection_path):
-        input_ = zarr.open(output_path, "r")[prediction_key]
-        detections = find_local_maxima(
-            input_, block_shape=block_shape, min_distance=2, threshold_abs=0.5, verbose=True, n_threads=16,
-        )
-        # Save the result in MoBIE compatible format.
-        detections = np.concatenate(
-            [np.arange(1, len(detections) + 1)[:, None], detections[:, ::-1]], axis=1
-        )
-        detections = pd.DataFrame(detections, columns=["spot_id", "x", "y", "z"])
-
-        # scale coordinates
-        detections["x"] *= voxel_size[0]
-        detections["y"] *= voxel_size[1]
-        detections["z"] *= voxel_size[2]
-
-        detections.to_csv(detection_path, index=False, sep="\t")
+    synapse_detection_from_prediction(
+        output_path, detection_path,
+        prediction_key=prediction_key,
+        block_shape=block_shape,
+        voxel_size=voxel_size,
+    )
 
 
 def marker_detection(
@@ -192,30 +288,16 @@ def marker_detection(
         skip_prediction = True
 
     if not skip_prediction:
+        out_channels = _get_model_out_channels(model_path)
         prediction_impl(
             input_path, input_key, output_folder, model_path,
-            scale=None, apply_postprocessing=False, output_channels=1,
+            scale=None, apply_postprocessing=False, output_channels=out_channels,
             block_shape=None, halo=None,
         )
 
     if not os.path.exists(detection_path):
-        input_ = zarr.open(output_path, "r")[prediction_key]
-        block_shape = tuple(input_.chunks)
-        detections = find_local_maxima(
-            input_, block_shape=block_shape, min_distance=2, threshold_abs=0.5, verbose=True, n_threads=16,
-        )
-        # Save the result in MoBIE compatible format.
-        detections = np.concatenate(
-            [np.arange(1, len(detections) + 1)[:, None], detections[:, ::-1]], axis=1
-        )
-        detections = pd.DataFrame(detections, columns=["spot_id", "x", "y", "z"])
-
-        # scale coordinates
-        detections["x"] *= voxel_size[0]
-        detections["y"] *= voxel_size[1]
-        detections["z"] *= voxel_size[2]
-
-        detections.to_csv(detection_path, index=False, sep="\t")
+        synapse_detection_from_prediction(output_path, detection_path,
+                                          prediction_key=prediction_key, voxel_size=voxel_size)
 
     else:
         with open(detection_path, "r") as f:

--- a/flamingo_tools/segmentation/synapse_detection.py
+++ b/flamingo_tools/segmentation/synapse_detection.py
@@ -64,7 +64,7 @@ def _flow_corrected_detections(pred, min_distance, threshold_abs, block_shape, n
     adjusted = np.empty((len(peak_coords), 3), dtype=float)
     for i, (z, y, x) in enumerate(peak_coords):
         zi, yi, xi = int(z), int(y), int(x)
-        w  = float(pred[1, zi, yi, xi])
+        w = float(pred[1, zi, yi, xi])
         vz = float(pred[2, zi, yi, xi])
         vy = float(pred[3, zi, yi, xi])
         vx = float(pred[4, zi, yi, xi])
@@ -175,7 +175,6 @@ def synapse_detection_from_prediction(
         detections.to_csv(detection_path, index=False, sep="\t")
     else:
         print(f"Skipping peak detection. {detection_path} already exists.")
-
 
 
 def run_prediction(

--- a/flamingo_tools/segmentation/synapse_detection.py
+++ b/flamingo_tools/segmentation/synapse_detection.py
@@ -141,6 +141,8 @@ def synapse_detection_from_prediction(
     prediction_key: str = "prediction",
     voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
     force_overwrite: bool = False,
+    threshold: Optional[float] = None,
+    model_path: Optional[str] = None,
 ):
     """Run synapse detection for prediction.
 
@@ -151,14 +153,28 @@ def synapse_detection_from_prediction(
         prediction_key: Input key for prediction.
         voxel_size: The voxel size of the data in micrometer.
         force_overwrite: Forcefully overwrite output detection.
+        threshold: Absolute heatmap threshold for peak detection. If None, the
+            threshold is loaded from cache or determined via gridsearch on the
+            validation set used during training (requires *model_path*).
+        model_path: Path to the model file. Required when *threshold* is None
+            and no cached threshold exists yet.
     """
+    if threshold is None:
+        if model_path is None:
+            raise ValueError(
+                "Either 'threshold' or 'model_path' must be supplied. "
+                "'model_path' is needed to run (or look up) the gridsearch threshold."
+            )
+        from flamingo_tools.synapse_detection.gridsearch import get_or_compute_threshold
+        threshold = get_or_compute_threshold(model_path)
+        print(f"Using detection threshold: {threshold:.3f}")
 
-    if not os.path.exists(detection_path) and not force_overwrite:
+    if not os.path.exists(detection_path) or force_overwrite:
         pred = zarr.open(prediction_path, "r")[prediction_key]
         # Use spatial chunk shape (drop leading channel dim for multi-channel predictions).
         det_block_shape = block_shape or tuple(pred.chunks[-3:])
         detections = _flow_corrected_detections(
-            pred, min_distance=2, threshold_abs=0.5,
+            pred, min_distance=2, threshold_abs=threshold,
             block_shape=det_block_shape, n_threads=16,
         )
         # Save the result in MoBIE compatible format.
@@ -185,6 +201,7 @@ def run_prediction(
     block_shape: Optional[Tuple[int, int, int]] = None,
     halo: Optional[Tuple[int, int, int]] = None,
     voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
+    threshold_flow: Optional[float] = None,
 ):
     """Run prediction for synapse detection.
 
@@ -219,6 +236,8 @@ def run_prediction(
         prediction_key=prediction_key,
         block_shape=block_shape,
         voxel_size=voxel_size,
+        threshold=threshold_flow,
+        model_path=model_path,
     )
 
 

--- a/flamingo_tools/segmentation/unet_prediction.py
+++ b/flamingo_tools/segmentation/unet_prediction.py
@@ -163,7 +163,6 @@ def prediction_impl(
         if output_channels > 1:
             postprocess = None
         else:
-
             postprocess = lambda x: x[0] if x.ndim == 4 else x.squeeze()
 
     gpu_ids, block_shape, halo = _get_device_and_tiling(block_shape, halo, input_)

--- a/flamingo_tools/segmentation/unet_prediction.py
+++ b/flamingo_tools/segmentation/unet_prediction.py
@@ -3,6 +3,7 @@ Parallelization using multiple GPUs is currently only possible by calling functi
 Functions for the parallelization end with '_slurm'
 and divide the process into preprocessing, prediction, and segmentation.
 """
+import importlib
 import json
 import multiprocessing as mp
 import os
@@ -29,6 +30,17 @@ from tqdm import tqdm
 
 import flamingo_tools.s3_utils as s3_utils
 from flamingo_tools.file_utils import read_image_data
+
+
+def _model_from_checkpoint(ckpt):
+    """Reconstruct a model from a torch_em-style trainer checkpoint dict."""
+    model_class_path = ckpt["init"]["model_class"]
+    model_kwargs = ckpt["init"]["model_kwargs"]
+    module_path, class_name = model_class_path.rsplit(".", 1)
+    model_class = getattr(importlib.import_module(module_path), class_name)
+    model = model_class(**model_kwargs)
+    model.load_state_dict(ckpt["model_state"])
+    return model
 
 
 class SelectChannel(SimpleTransformationWrapper):
@@ -93,7 +105,8 @@ def prediction_impl(
         if os.path.isdir(model_path):
             model = load_model(model_path)
         else:
-            model = torch.load(model_path, weights_only=False)
+            obj = torch.load(model_path, weights_only=False)
+            model = _model_from_checkpoint(obj) if isinstance(obj, dict) and "model_state" in obj else obj
 
     input_ = read_image_data(input_path, input_key)
     chunks = getattr(input_, "chunks", (64, 64, 64))
@@ -147,7 +160,11 @@ def prediction_impl(
             x[1] = vigra.filters.gaussianSmoothing(x[1], sigma=2.0)
             return x
     else:
-        postprocess = None if output_channels > 1 else lambda x: x.squeeze()
+        if output_channels > 1:
+            postprocess = None
+        else:
+
+            postprocess = lambda x: x[0] if x.ndim == 4 else x.squeeze()
 
     gpu_ids, block_shape, halo = _get_device_and_tiling(block_shape, halo, input_)
     shape = input_.shape

--- a/flamingo_tools/synapse_detection/detection_dataset.py
+++ b/flamingo_tools/synapse_detection/detection_dataset.py
@@ -5,8 +5,13 @@ import zarr
 
 from skimage.filters import gaussian
 from skimage.feature import peak_local_max
-from torch_em.transform.raw import standardize
 from torch_em.util import ensure_tensor_with_channels
+
+try:
+    from spotiflow.utils import points_to_flow3d
+    _spotiflow_available = True
+except ImportError:
+    _spotiflow_available = False
 
 
 class MinPointSampler:
@@ -78,6 +83,74 @@ def process_labels(coords, shape, sigma, eps, bb=None):
     labels /= (labels.max() + 1e-7)
     labels *= 4
     return labels
+
+
+class CsvHeatmapFlowTransform:
+    """Label transform for CSV point annotations that matches the HeatmapFlowTransform interface.
+
+    The upstream czii-protein-challenge HeatmapFlowTransform reads JSON annotation files.
+    This class reads the CSV files used by the local synapse training data and produces
+    the same 5-channel output (1 Gaussian heatmap + 4 stereographic flow channels).
+
+    Args:
+        sigma: Gaussian standard deviation (in voxels) for the heatmap.
+        eps: Small constant added when normalizing the heatmap.
+    """
+
+    def __init__(self, sigma: float, eps: float = 1e-8):
+        if not _spotiflow_available:
+            raise ImportError(
+                "spotiflow is required for flow computation. "
+                "Install it with: pip install spotiflow"
+            )
+        self.sigma = sigma
+        self.eps = eps
+
+    def __call__(self, label_path, shape, bb_labels, bb_for_loading):
+        # Strip a leading channel slice if present (bb_labels may have one).
+        bb = bb_for_loading[-3:] if len(bb_for_loading) > 3 else bb_for_loading
+        local_shape = tuple(s.stop - s.start for s in bb)
+        z_min, y_min, x_min = bb[0].start, bb[1].start, bb[2].start
+        z_max, y_max, x_max = bb[0].stop, bb[1].stop, bb[2].stop
+
+        # Load all point coordinates from the CSV once.
+        points_df = pd.read_csv(label_path)
+        z_abs = points_df["axis-0"].values.astype(np.float32)
+        y_abs = points_df["axis-1"].values.astype(np.float32)
+        x_abs = points_df["axis-2"].values.astype(np.float32)
+
+        # Filter to the bounding box and convert to local coordinates.
+        mask = (
+            (z_abs >= z_min) & (z_abs < z_max) &
+            (y_abs >= y_min) & (y_abs < y_max) &
+            (x_abs >= x_min) & (x_abs < x_max)
+        )
+        local_z = z_abs[mask] - z_min
+        local_y = y_abs[mask] - y_min
+        local_x = x_abs[mask] - x_min
+        n_points = int(mask.sum())
+
+        # Gaussian heatmap (1 channel).
+        heatmap = np.zeros(local_shape, dtype=np.float32)
+        if n_points > 0:
+            coords = tuple(
+                np.clip(np.round(c).astype(int), 0, s - 1)
+                for c, s in zip([local_z, local_y, local_x], local_shape)
+            )
+            heatmap[coords] = 1
+            heatmap = gaussian(heatmap, self.sigma)
+            heatmap /= (heatmap.max() + self.eps)
+            heatmap *= 4
+
+        # Stereographic flow (4 channels).
+        if n_points == 0:
+            flow = np.zeros((4, *local_shape), dtype=np.float32)
+        else:
+            local_points = np.stack([local_z, local_y, local_x], axis=1)  # (N, 3)
+            flow = points_to_flow3d(local_points, local_shape)  # returns (Z', Y', X', 4) channels last
+            flow = np.asarray(flow, dtype=np.float32).transpose((3, 0, 1, 2))  # → (4, Z', Y', X')
+
+        return np.concatenate([heatmap[np.newaxis], flow], axis=0).astype(np.float32)
 
 
 class DetectionDataset(torch.utils.data.Dataset):
@@ -247,21 +320,3 @@ class DetectionDataset(torch.utils.data.Dataset):
         raw = ensure_tensor_with_channels(raw, ndim=self._ndim, dtype=self.dtype)
         labels = ensure_tensor_with_channels(labels, ndim=self._ndim, dtype=self.label_dtype)
         return raw, labels
-
-
-if __name__ == "__main__":
-    import napari
-
-    raw_path = "training_data/images/10.1L_mid_IHCribboncount_5_Z.zarr"
-    label_path = "training_data/labels/10.1L_mid_IHCribboncount_5_Z.csv"
-
-    f = zarr.open(raw_path, "r")
-    raw = f["raw"][:]
-
-    coords, _ = load_labels(label_path, raw.shape, bb=None)
-    labels = process_labels(coords, shape=raw.shape, sigma=1, eps=1e-7)
-
-    v = napari.Viewer()
-    v.add_image(raw)
-    v.add_image(labels)
-    napari.run()

--- a/flamingo_tools/synapse_detection/gridsearch.py
+++ b/flamingo_tools/synapse_detection/gridsearch.py
@@ -1,0 +1,216 @@
+"""Threshold gridsearch for synapse heatmap detection.
+
+Replaces the czii-protein-challenge gridsearch with flamingo-tools-compatible
+equivalents: CSV label files instead of CZII JSON, prediction_impl instead of
+get_prediction_torch_em, and inlined metric_coords.
+"""
+
+import json
+import os
+import warnings
+
+import numpy as np
+import pandas as pd
+from scipy.optimize import linear_sum_assignment
+from scipy.spatial.distance import cdist
+from skimage.feature import peak_local_max
+from tqdm import tqdm
+
+from flamingo_tools.segmentation.unet_prediction import prediction_impl
+
+TRAIN_ROOT = "/mnt/vast-nhr/projects/nim00007/data/moser/cochlea-lightsheet/training_data/synapses/training_data/v4/images"
+LABEL_ROOT = "/mnt/vast-nhr/projects/nim00007/data/moser/cochlea-lightsheet/training_data/synapses/training_data/v4/labels"
+DEFAULT_JSON = "/mnt/vast-nhr/projects/nim00007/data/moser/cochlea-lightsheet/training_data/synapses/training_data/v4/train_val_split.json"
+
+
+# ---------------------------------------------------------------------------
+# Coordinate matching metric (inlined from czii evaluation_metrics.py)
+# ---------------------------------------------------------------------------
+
+def _metric_coords(gts, preds, match_distance=4):
+    """Compute precision, recall, and F1 for two sets of 3-D coordinates.
+
+    Uses Hungarian matching; a predicted point counts as a true positive when
+    it lies within *match_distance* voxels of its assigned ground-truth point.
+
+    Args:
+        gts: (N, 3) array of ground-truth coordinates [z, y, x].
+        preds: (M, 3) array of predicted coordinates [z, y, x].
+        match_distance: Maximum voxel distance for a valid match.
+
+    Returns:
+        Tuple (precision, recall, f1).
+    """
+    n, m = len(gts), len(preds)
+    if n == 0 and m == 0:
+        return 1.0, 1.0, 1.0
+    if n == 0 or m == 0:
+        return 0.0, 0.0, 0.0
+
+    dist = cdist(gts, preds, metric="euclidean")
+    if not np.any(dist < match_distance):
+        return 0.0, 0.0, 0.0
+
+    max_d = dist.max()
+    costs = -(dist < match_distance).astype(float) - (max_d - dist) / (max_d + 1e-8)
+    row_ind, col_ind = linear_sum_assignment(costs)
+    tp = int(np.count_nonzero(dist[row_ind, col_ind] < match_distance))
+
+    precision = tp / m if m > 0 else 0.0
+    recall = tp / n if n > 0 else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) > 0 else 0.0
+    return precision, recall, f1
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_csv_labels(label_path):
+    """Return (N, 3) voxel coordinate array [z, y, x] from a napari CSV file."""
+    df = pd.read_csv(label_path)
+    return np.stack([df["axis-0"].values, df["axis-1"].values, df["axis-2"].values], axis=1)
+
+
+def _get_out_channels(model_path):
+    """Return the number of output channels from a model file or trainer checkpoint."""
+    try:
+        import sys
+        import flamingo_tools.synapse_detection.detection_dataset as _dd
+        sys.modules.setdefault("detection_dataset", _dd)
+    except ImportError:
+        pass
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        import torch
+        obj = torch.load(model_path, map_location="cpu", weights_only=False)
+    if isinstance(obj, dict) and "model_state" in obj:
+        return obj["init"]["model_kwargs"].get("out_channels", 1)
+    return obj.state_dict()["out_conv.bias"].shape[0]
+
+
+# ---------------------------------------------------------------------------
+# Gridsearch
+# ---------------------------------------------------------------------------
+
+def gridsearch(
+    json_val_path,
+    model_path,
+    image_dir=TRAIN_ROOT,
+    label_dir=LABEL_ROOT,
+    raw_key="raw",
+    out_channels=None,
+    block_shape=(64, 256, 256),
+    halo=(16, 32, 32),
+    min_distance=2,
+    match_distance=4,
+):
+    """Find the peak-detection threshold that maximises F1 on the validation set.
+
+    The JSON at *json_val_path* must contain a ``"val"`` key whose value is a
+    list of image file names (e.g. ``"sample_001.zarr"``).  Images are looked
+    up in *image_dir*; labels are looked up in *label_dir* after replacing the
+    ``.zarr`` extension with ``.csv``.  Absolute paths in the val list are used
+    directly.
+
+    Args:
+        json_val_path: Path to the JSON train/val split file.
+        model_path: Path to the model checkpoint or exported model file.
+        image_dir: Directory containing the validation zarr files.
+        label_dir: Directory containing the matching CSV label files.
+        raw_key: Zarr key for the raw image data.
+        out_channels: Number of model output channels.  Auto-detected if None.
+        block_shape: Spatial block shape for tiled prediction.
+        halo: Halo (overlap) for tiled prediction.
+        min_distance: Minimum voxel distance between detected peaks.
+        match_distance: Maximum voxel distance for a GT/pred match (in voxels).
+
+    Returns:
+        Best threshold as a float.
+    """
+    if out_channels is None:
+        out_channels = _get_out_channels(model_path)
+
+    with open(json_val_path) as f:
+        val_list = json.load(f)["val"]
+
+    threshes = np.round(np.arange(0.3, 2.0, 0.1), 2)
+    records = []
+
+    for val_name in val_list:
+        # Resolve image path.
+        image_path = f"{val_name}.zarr" if os.path.isabs(val_name) else os.path.join(image_dir, f"{val_name}.zarr")
+        # Derive label path: same basename, .csv extension, in label_dir.
+        label_name = os.path.splitext(os.path.basename(val_name))[0] + ".csv"
+        label_path = os.path.join(label_dir, label_name)
+
+        print(f"Running prediction on {image_path}")
+        _, pred = prediction_impl(
+            image_path, raw_key, None, model_path,
+            scale=None, block_shape=block_shape, halo=halo,
+            apply_postprocessing=False, output_channels=out_channels,
+        )
+        # Use heatmap channel only for threshold sweep.
+        heatmap = pred[0] if pred.ndim == 4 else pred
+
+        label_coords = _load_csv_labels(label_path)
+        print(f"  {len(label_coords)} ground-truth points loaded")
+
+        for thresh in tqdm(threshes, desc=f"  threshold sweep"):
+            pred_coords = peak_local_max(heatmap, min_distance=min_distance, threshold_abs=thresh)
+            _, _, f1 = _metric_coords(label_coords, pred_coords, match_distance)
+            records.append({"val": val_name, "threshold": float(thresh), "f1": float(f1)})
+
+    # Aggregate F1 across validation samples and find the best threshold.
+    df = pd.DataFrame(records)
+    mean_f1 = df.groupby("threshold")["f1"].mean()
+    best_thresh = float(mean_f1.idxmax())
+    print(f"Best threshold: {best_thresh:.2f}  (mean F1={mean_f1.max():.3f})")
+    return best_thresh
+
+
+# ---------------------------------------------------------------------------
+# Cached wrapper
+# ---------------------------------------------------------------------------
+
+def get_or_compute_threshold(
+    model_path,
+    json_val_path=DEFAULT_JSON,
+    image_dir=TRAIN_ROOT,
+    label_dir=LABEL_ROOT,
+    **gridsearch_kwargs,
+):
+    """Return the cached detection threshold for *model_path*, running gridsearch if needed.
+
+    The threshold is stored as ``<model_path_without_extension>_threshold.json``
+    alongside the model file.  Subsequent calls skip the gridsearch and return
+    the cached value immediately.
+
+    Args:
+        model_path: Path to the model file (used both for prediction and as the
+            cache key).
+        json_val_path: Path to the JSON train/val split file.
+        image_dir: Directory containing validation zarr files.
+        label_dir: Directory containing validation CSV label files.
+        **gridsearch_kwargs: Forwarded to :func:`gridsearch` (e.g. ``block_shape``,
+            ``min_distance``, ``match_distance``).
+
+    Returns:
+        Optimal detection threshold as a float.
+    """
+    cache_path = os.path.splitext(model_path)[0] + "_threshold.json"
+
+    if os.path.exists(cache_path):
+        with open(cache_path) as f:
+            threshold = json.load(f)["threshold"]
+        print(f"Loaded cached threshold {threshold:.3f} from {cache_path}")
+        return threshold
+
+    threshold = gridsearch(
+        json_val_path, model_path, image_dir=image_dir, label_dir=label_dir,
+        **gridsearch_kwargs,
+    )
+    with open(cache_path, "w") as f:
+        json.dump({"threshold": float(threshold)}, f, indent=2)
+    print(f"Threshold {threshold:.3f} saved to {cache_path}")
+    return threshold

--- a/flamingo_tools/synapse_detection/gridsearch.py
+++ b/flamingo_tools/synapse_detection/gridsearch.py
@@ -198,6 +198,8 @@ def get_or_compute_threshold(
     Returns:
         Optimal detection threshold as a float.
     """
+    _DEFAULT_THRESHOLD = 0.9
+
     cache_path = os.path.splitext(model_path)[0] + "_threshold.json"
 
     if os.path.exists(cache_path):
@@ -205,6 +207,16 @@ def get_or_compute_threshold(
             threshold = json.load(f)["threshold"]
         print(f"Loaded cached threshold {threshold:.3f} from {cache_path}")
         return threshold
+
+    if not os.path.exists(json_val_path):
+        import warnings
+        warnings.warn(
+            f"Threshold cache not found and validation JSON does not exist at '{json_val_path}'. "
+            f"Using default threshold {_DEFAULT_THRESHOLD}. "
+            "Run gridsearch with a valid json_val_path to determine an optimal threshold.",
+            UserWarning,
+        )
+        return _DEFAULT_THRESHOLD
 
     threshold = gridsearch(
         json_val_path, model_path, image_dir=image_dir, label_dir=label_dir,

--- a/scripts/synapse_marker_detection/export_model.py
+++ b/scripts/synapse_marker_detection/export_model.py
@@ -6,14 +6,14 @@ import sys
 import torch
 from torch_em.util import load_model
 
+import flamingo_tools.synapse_detection.detection_dataset as _dd
+
+# Allow loading checkpoints that were saved when detection_dataset was a local script.
+sys.modules["detection_dataset"] = _dd
+
 sys.path.append("/home/pape/Work/my_projects/czii-protein-challenge")
 sys.path.append("/user/pape41/u12086/Work/my_projects/czii-protein-challenge")
 sys.path.append("/user/schilling40/u15000/czii-protein-challenge")
-
-# Allow loading checkpoints that were saved when detection_dataset was a local script.
-import flamingo_tools.synapse_detection.detection_dataset as _dd
-
-sys.modules["detection_dataset"] = _dd
 
 
 def _model_from_checkpoint(ckpt):

--- a/scripts/synapse_marker_detection/export_model.py
+++ b/scripts/synapse_marker_detection/export_model.py
@@ -1,4 +1,6 @@
 import argparse
+import importlib
+import os
 import sys
 
 import torch
@@ -6,10 +8,35 @@ from torch_em.util import load_model
 
 sys.path.append("/home/pape/Work/my_projects/czii-protein-challenge")
 sys.path.append("/user/pape41/u12086/Work/my_projects/czii-protein-challenge")
+sys.path.append("/user/schilling40/u15000/czii-protein-challenge")
+
+# Allow loading checkpoints that were saved when detection_dataset was a local script.
+import flamingo_tools.synapse_detection.detection_dataset as _dd
+
+sys.modules["detection_dataset"] = _dd
+
+
+def _model_from_checkpoint(ckpt):
+    """Reconstruct a model from a torch_em-style trainer checkpoint dict."""
+    model_class_path = ckpt["init"]["model_class"]
+    model_kwargs = ckpt["init"]["model_kwargs"]
+    module_path, class_name = model_class_path.rsplit(".", 1)
+    model_class = getattr(importlib.import_module(module_path), class_name)
+    model = model_class(**model_kwargs)
+    model.load_state_dict(ckpt["model_state"])
+    return model
 
 
 def export_model(input_, output):
-    model = load_model(input_, device="cpu")
+    if os.path.isdir(input_):
+        model = load_model(input_, device="cpu")
+    else:
+        obj = torch.load(input_, map_location="cpu", weights_only=False)
+        if isinstance(obj, dict) and "model_state" in obj:
+            model = _model_from_checkpoint(obj)
+        else:
+            model = obj
+    model.eval()
     torch.save(model, output)
 
 

--- a/scripts/synapse_marker_detection/train_synapse_detection.py
+++ b/scripts/synapse_marker_detection/train_synapse_detection.py
@@ -1,10 +1,11 @@
 import argparse
+import json
 import os
 import sys
 from glob import glob
 
 from sklearn.model_selection import train_test_split
-from detection_dataset import DetectionDataset, MinPointSampler, CsvHeatmapFlowTransform
+from flamingo_tools.synapse_detection.detection_dataset import DetectionDataset, MinPointSampler, CsvHeatmapFlowTransform
 
 sys.path.append("/home/pape/Work/my_projects/czii-protein-challenge")
 sys.path.append("/user/schilling40/u15000/czii-protein-challenge/detection")
@@ -14,34 +15,30 @@ from utils.training.training import supervised_training  # noqa
 ROOT_SYNAPSE_DATA = "/mnt/vast-nhr/projects/nim00007/data/moser/cochlea-lightsheet/training_data/synapses/training_data"  # noqa
 
 
-def get_paths(image_dir, label_dir, split):
-    image_paths = sorted(glob(os.path.join(image_dir, "*.zarr")))
-    label_paths = sorted(glob(os.path.join(label_dir, "*.csv")))
-    assert len(image_paths) == len(label_paths)
-
-    train_images, val_images, train_labels, val_labels = train_test_split(
-        image_paths, label_paths, test_size=2, random_state=42
-    )
-
-    if split == "train":
-        image_paths = train_images
-        label_paths = train_labels
-    else:
-        image_paths = val_images
-        label_paths = val_labels
-
-    return image_paths, label_paths
-
-
-def train(root_data_dir, version="v4"):
+def train(root_data_dir, version="v4", val_sample_size=3):
     image_dir = os.path.join(root_data_dir, version, "images")
     label_dir = os.path.join(root_data_dir, version, "labels")
     model_name = f"synapse_detection_{version}"
 
-    train_paths, train_label_paths = get_paths(image_dir, label_dir, "train")
-    val_paths, val_label_paths = get_paths(image_dir, label_dir, "val")
+    image_paths = sorted(glob(os.path.join(image_dir, "*.zarr")))
+    label_paths = sorted(glob(os.path.join(label_dir, "*.csv")))
+    assert len(image_paths) == len(label_paths)
+
+    train_paths, val_paths, train_label_paths, val_label_paths = train_test_split(
+        image_paths, label_paths, test_size=val_sample_size, random_state=42
+    )
+
     # We need to give the paths for the test loader, although it's never used.
     test_paths, test_label_paths = val_paths, val_label_paths
+
+    train_val_dic = {
+        "train": [os.path.splitext(os.path.basename(f))[0] for f in train_paths],
+        "val": [os.path.splitext(os.path.basename(f))[0] for f in val_paths],
+    }
+
+    json_path = os.path.join(root_data_dir, version, "train_val_split.json")
+    with open(json_path, "w") as f:
+        json.dump(train_val_dic, f, indent='\t', separators=(',', ': '))
 
     print("Start training with:")
     print(len(train_paths), "tomograms for training")

--- a/scripts/synapse_marker_detection/train_synapse_detection.py
+++ b/scripts/synapse_marker_detection/train_synapse_detection.py
@@ -4,7 +4,7 @@ import sys
 from glob import glob
 
 from sklearn.model_selection import train_test_split
-from detection_dataset import DetectionDataset, MinPointSampler
+from detection_dataset import DetectionDataset, MinPointSampler, CsvHeatmapFlowTransform
 
 sys.path.append("/home/pape/Work/my_projects/czii-protein-challenge")
 sys.path.append("/user/schilling40/u15000/czii-protein-challenge/detection")
@@ -64,6 +64,7 @@ def train(root_data_dir, version="v4"):
         n_iterations=int(1e5),
         out_channels=5,
         augmentations=None,
+        label_transform=CsvHeatmapFlowTransform(sigma=1, eps=1e-5),
         eps=1e-5,
         sigma=1,
         lower_bound=None,
@@ -75,6 +76,7 @@ def train(root_data_dir, version="v4"):
         n_samples_train=3200,
         n_samples_val=160,
         sampler=MinPointSampler(min_points=1, p_reject=0.8),
+        num_workers=8,
     )
 
 

--- a/scripts/synapse_marker_detection/train_val_split_v4.json
+++ b/scripts/synapse_marker_detection/train_val_split_v4.json
@@ -1,0 +1,26 @@
+{
+	"train": [
+		"227l_p650_base_vglut3-ctbp2",
+		"m78l_basep2970_cr-ctbp2",
+		"m226r_base_p800_vglut3-ctbp2",
+		"mlr226r_vglut3ctbp2_apex2",
+		"MLR227-L_0403-0991-0491_Vglut3-CTBP2_mod-1",
+		"mlr227-l_0973-0489-0404_vglut3-ctbp2_mod-1",
+		"mlr227-l_0672-0821-1201_vglut3-ctbp2_mod-2",
+		"mlr226r_vglut3ctbp2_base2",
+		"227l_p720_apex_vglut3-ctbp2",
+		"m78l_midp480_cr-ctbp2",
+		"mlr227-l_1121-1013-0931_vglut3-ctbp2_mod-2",
+		"m226r_apex_p1268_pv-ctbp2",
+		"mlr226r_vglut3ctbp2_base1",
+		"m78l_apexp2718_cr-ctbp2",
+		"mlr226r_vglut3ctbp2_apex1",
+		"mlr226r_vglut3ctbp2_mid1",
+		"m226r_mid_p2824_vglut3-ctbp2"
+	],
+	"val": [
+		"227l_p2466_mid_vlugt3-ctbp2",
+		"mlr227-l_0697-1303-0436_vglut3-ctbp2_mod-1",
+		"mlr226r_vglut3ctbp2_mid2"
+	]
+}

--- a/scripts/validation/synapses/prediction.py
+++ b/scripts/validation/synapses/prediction.py
@@ -184,11 +184,11 @@ def main():
 
     args = parser.parse_args()
     process_everything(
-        input_root = args.input_root,
-        gt_root = args.gt_root,
-        output_root = args.output_root,
-        synapse_model_path = args.model_synapse,
-        ihc_model_path = args.model_ihc,
+        input_root=args.input_root,
+        gt_root=args.gt_root,
+        output_root=args.output_root,
+        synapse_model_path=args.model_synapse,
+        ihc_model_path=args.model_ihc,
     )
     # check_predictions()
 

--- a/scripts/validation/synapses/prediction.py
+++ b/scripts/validation/synapses/prediction.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import sys
 from glob import glob
@@ -7,23 +8,26 @@ import numpy as np
 import pandas as pd
 
 from elf.io import open_file
-from elf.parallel.local_maxima import find_local_maxima
 from flamingo_tools.segmentation.unet_prediction import prediction_impl, run_unet_prediction
+from flamingo_tools.segmentation.synapse_detection import synapse_detection_from_prediction
 
 INPUT_ROOT = "/mnt/vast-nhr/projects/nim00007/data/moser/cochlea-lightsheet/training_data/synapses/test_data/v3/images"  # noqa
 GT_ROOT = "/mnt/vast-nhr/projects/nim00007/data/moser/cochlea-lightsheet/training_data/synapses/test_data/v3/labels"
 OUTPUT_ROOT = "/mnt/vast-nhr/projects/nim00007/data/moser/cochlea-lightsheet/AnnotatedImageCrops/SynapseValidation"
+SYNAPSE_MODEL = "/mnt/vast-nhr/projects/nim00007/data/moser/cochlea-lightsheet/trained_models/Synapses/synapse_detection_model_v3.pt"  # noqa
+IHC_MODEL = "/mnt/vast-nhr/projects/nim00007/data/moser/cochlea-lightsheet/trained_models/IHC/v4_cochlea_distance_unet_IHC_supervised_2025-07-14"  # noqa
 
 sys.path.append("/user/pape41/u12086/Work/my_projects/czii-protein-challenge")
 sys.path.append("../../synapse_marker_detection")
 
 
-def pred_synapse_impl(input_path, output_folder):
-    model_path = "/mnt/vast-nhr/home/pape41/u12086/Work/my_projects/flamingo-tools/scripts/synapse_marker_detection/checkpoints/synapse_detection_v3"  # noqa
+def pred_synapse_impl(input_path, output_folder, model_path):
     input_key = "raw"
 
     block_shape = (32, 128, 128)
     halo = (16, 64, 64)
+
+    os.makedirs(output_folder, exist_ok=True)
 
     prediction_impl(
         input_path, input_key, output_folder, model_path,
@@ -32,53 +36,46 @@ def pred_synapse_impl(input_path, output_folder):
     )
 
     output_path = os.path.join(output_folder, "predictions.zarr")
-    prediction_key = "prediction"
-    input_ = open_file(output_path, "r")[prediction_key]
-
-    detections = find_local_maxima(
-        input_, block_shape=block_shape, min_distance=2, threshold_abs=0.5, verbose=True, n_threads=4,
-    )
-    # Save the result in mobie compatible format.
-    detections = np.concatenate(
-        [np.arange(1, len(detections) + 1)[:, None], detections[:, ::-1]], axis=1
-    )
-    detections = pd.DataFrame(detections, columns=["spot_id", "x", "y", "z"])
-
     detection_path = os.path.join(output_folder, "synapse_detection.tsv")
-    detections.to_csv(detection_path, index=False, sep="\t")
+
+    prediction_key = "prediction"
+    synapse_detection_from_prediction(
+        output_path, detection_path,
+        prediction_key=prediction_key,
+        block_shape=block_shape,
+    )
 
 
-def predict_synapses():
-    files = sorted(glob(os.path.join(INPUT_ROOT, "*.zarr")))
+def predict_synapses(input_root, output_root, model_path):
+    files = sorted(glob(os.path.join(input_root, "*.zarr")))
     for ff in files:
-        output_folder = os.path.join(OUTPUT_ROOT, Path(ff).stem)
+        output_folder = os.path.join(output_root, Path(ff).stem)
         if os.path.exists(os.path.join(output_folder, "predictions.zarr", "prediction")):
             print("Synapse prediction in", ff, "already done")
             continue
         else:
             print("Predicting synapses in", ff)
-        pred_synapse_impl(ff, output_folder)
+        pred_synapse_impl(ff, output_folder, model_path)
 
 
-def pred_ihc_impl(input_path, output_folder):
-    model_path = "/mnt/vast-nhr/projects/nim00007/data/moser/cochlea-lightsheet/trained_models/IHC/v2_cochlea_distance_unet_IHC_supervised_2025-05-21"  # noqa
-
+def pred_ihc_impl(input_path, output_folder, model_path):
     run_unet_prediction(
         input_path, input_key="raw_ihc", output_folder=output_folder, model_path=model_path, min_size=1000,
-        seg_class="ihc", center_distance_threshold=0.5, boundary_distance_threshold=0.5,
+        seg_class="ihc", center_distance_threshold=0.5, boundary_distance_threshold=0.6,
+        distance_smoothing=0.6,
     )
 
 
-def predict_ihcs():
-    files = sorted(glob(os.path.join(INPUT_ROOT, "*.zarr")))
+def predict_ihcs(input_root, output_root, model_path):
+    files = sorted(glob(os.path.join(input_root, "*.zarr")))
     for ff in files:
-        output_folder = os.path.join(OUTPUT_ROOT, f"{Path(ff).stem}_ihc")
+        output_folder = os.path.join(output_root, f"{Path(ff).stem}_ihc")
         if os.path.exists(os.path.join(output_folder, "predictions.zarr", "prediction")):
             print("IHC segmentation in", ff, "already done")
             continue
         else:
             print("Segmenting IHCs in", ff)
-        pred_ihc_impl(ff, output_folder)
+        pred_ihc_impl(ff, output_folder, model_path)
 
 
 def _filter_synapse_impl(detections, ihc_file, output_path):
@@ -96,22 +93,22 @@ def _filter_synapse_impl(detections, ihc_file, output_path):
     filtered_detections.to_csv(output_path, index=False, sep="\t")
 
 
-def filter_synapses():
-    input_files = sorted(glob(os.path.join(INPUT_ROOT, "*.zarr")))
+def filter_synapses(input_root, output_root):
+    input_files = sorted(glob(os.path.join(input_root, "*.zarr")))
     for ff in input_files:
-        ihc = os.path.join(OUTPUT_ROOT, f"{Path(ff).stem}_ihc", "segmentation.zarr")
-        output_folder = os.path.join(OUTPUT_ROOT, Path(ff).stem)
+        ihc = os.path.join(output_root, f"{Path(ff).stem}_ihc", "segmentation.zarr")
+        output_folder = os.path.join(output_root, Path(ff).stem)
         synapses = os.path.join(output_folder, "synapse_detection.tsv")
         synapses = pd.read_csv(synapses, sep="\t")
         output_path = os.path.join(output_folder, "filtered_synapse_detection.tsv")
         _filter_synapse_impl(synapses, ihc, output_path)
 
 
-def filter_gt():
-    input_files = sorted(glob(os.path.join(INPUT_ROOT, "*.zarr")))
-    gt_files = sorted(glob(os.path.join(GT_ROOT, "*.csv")))
+def filter_gt(input_root, gt_root, output_root):
+    input_files = sorted(glob(os.path.join(input_root, "*.zarr")))
+    gt_files = sorted(glob(os.path.join(gt_root, "*.csv")))
     for ff, gt in zip(input_files, gt_files):
-        ihc = os.path.join(OUTPUT_ROOT, f"{Path(ff).stem}_ihc", "segmentation.zarr")
+        ihc = os.path.join(output_root, f"{Path(ff).stem}_ihc", "segmentation.zarr")
         output_folder, fname = os.path.split(gt)
         output_path = os.path.join(output_folder, fname.replace(".csv", "_filtered.tsv"))
 
@@ -139,24 +136,61 @@ def _check_prediction(input_file, ihc_file, detection_file):
     napari.run()
 
 
-def check_predictions():
-    input_files = sorted(glob(os.path.join(INPUT_ROOT, "*.zarr")))
+def check_predictions(input_root, output_root):
+    input_files = sorted(glob(os.path.join(input_root, "*.zarr")))
     for ff in input_files:
-        ihc = os.path.join(OUTPUT_ROOT, f"{Path(ff).stem}_ihc", "segmentation.zarr")
-        synapses = os.path.join(OUTPUT_ROOT, Path(ff).stem, "filtered_synapse_detection.tsv")
+        ihc = os.path.join(output_root, f"{Path(ff).stem}_ihc", "segmentation.zarr")
+        synapses = os.path.join(output_root, Path(ff).stem, "filtered_synapse_detection.tsv")
         _check_prediction(ff, ihc, synapses)
 
 
-def process_everything():
-    predict_synapses()
-    predict_ihcs()
-    filter_synapses()
-    filter_gt()
+def process_everything(
+    input_root,
+    gt_root,
+    output_root,
+    synapse_model_path,
+    ihc_model_path,
+):
+    predict_synapses(input_root, output_root, synapse_model_path)
+    predict_ihcs(input_root, output_root, ihc_model_path)
+    filter_synapses(input_root, output_root)
+    filter_gt(input_root, gt_root, output_root)
 
 
 def main():
-    # process_everything()
-    check_predictions()
+    parser = argparse.ArgumentParser(
+        description="Process test data for synapse detection."
+    )
+    parser.add_argument(
+        "-i", "--input_root", type=str, default=INPUT_ROOT,
+        help="Folder that contains the data of the CTBP2 [raw] and the IHC [raw_ihc] channel."
+    )
+    parser.add_argument(
+        "-g", "--gt_root", type=str, default=GT_ROOT,
+        help="Folder that contains the ground truth data of the synapses."
+    )
+    parser.add_argument(
+        "-o", "--output_root", type=str, default=OUTPUT_ROOT,
+        help="Output path where the predicted synapses, IHC segmentation and filtered synapses will be saved."
+    )
+    parser.add_argument(
+        "--model_synapse", type=str, default=SYNAPSE_MODEL,
+        help="File path to synapse detection model."
+    )
+    parser.add_argument(
+        "--model_ihc", type=str, default=IHC_MODEL,
+        help="File path to model for IHC segmentation."
+    )
+
+    args = parser.parse_args()
+    process_everything(
+        input_root = args.input_root,
+        gt_root = args.gt_root,
+        output_root = args.output_root,
+        synapse_model_path = args.model_synapse,
+        ihc_model_path = args.model_ihc,
+    )
+    # check_predictions()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Prepares the synapse detection pipeline for the v4 model, which produces a
5-channel heatmap+flow output. The PR fixes model loading failures, wires in
stereographic flow-based coordinate refinement, and adds a gridsearch to find
the optimal detection threshold from the training validation set.

---

## Changes

### Training (`detection_dataset.py`, `train_synapse_detection.py`)

`detection_dataset.py` is moved from `scripts/synapse_marker_detection/` into
the installed package at `flamingo_tools/synapse_detection/detection_dataset.py`.
As a local script it had no stable import path, causing
`ModuleNotFoundError: No module named 'detection_dataset'` whenever PyTorch
tried to unpickle a checkpoint that referenced its classes.

A new `CsvHeatmapFlowTransform` class is added to the module. It matches the
`HeatmapFlowTransform` interface from `czii-protein-challenge` but reads the
napari CSV label format (`axis-0/1/2`) used in the synapse training data,
producing the same 5-channel output: one Gaussian heatmap (σ = 1 voxel,
normalised to [0, 4]) plus four stereographic flow channels via
`spotiflow.utils.points_to_flow3d`. The training script is updated to pass this
transform as `label_transform` and a `train_val_split_v4.json` is added for
gridsearch use.

### Model export / loading (`export_model.py`, `unet_prediction.py`)

`export_model.py` now handles three input formats: a torch_em trainer directory
(existing behaviour), a raw trainer checkpoint dict (keys `model_state` + `init`
→ model class and kwargs are read and the model is reconstructed), and a
pre-exported full model file (passed through).

The same `_model_from_checkpoint` helper is added to `prediction_impl` in
`unet_prediction.py` so checkpoint dicts can be passed directly as `model_path`
without a prior export step. For existing checkpoints saved when
`detection_dataset` was a local script, a `sys.modules` alias is registered at
load time so unpickling succeeds.

The single-output postprocess lambda is also fixed:
`lambda x: x.squeeze()` → `lambda x: x[0] if x.ndim == 4 else x.squeeze()`.
The old form left a `(5, Z, Y, X)` block unchanged, causing a shape mismatch
when writing into the 3D output zarr. The fix selects channel 0 (heatmap)
from any multi-channel model while keeping existing single-channel models
unaffected.

### Inference pipeline (`synapse_detection.py`)

`run_prediction` and `marker_detection` now auto-detect the number of model
output channels (`_get_model_out_channels`) and pass that count to
`prediction_impl`, so all 5 channels are stored in the output zarr.

Peak detection and post-processing are extracted into a shared helper
`synapse_detection_from_prediction` which both functions delegate to. After
`find_local_maxima` detects integer-voxel peaks in the heatmap (channel 0 via a
`SelectChannel` wrapper for out-of-core access), flow channels 1–4 are read at
each peak position from zarr and the stereographic back-projection is applied:

```
δ = σ · v / (1 + w + ε),   σ = 1  (matches training sigma)
```

This refines each detected location to sub-voxel precision without loading the
full multi-channel volume into memory.

### Threshold gridsearch (`flamingo_tools/synapse_detection/gridsearch.py`)

A new module replaces the CZII-specific gridsearch with a flamingo-tools-
compatible implementation. All upstream imports are removed; `metric_coords` is
inlined (scipy only), `get_prediction_torch_em` is replaced by
`prediction_impl`, and label reading uses the napari CSV format instead of CZII
JSON. The threshold is swept over [0.3, 2.0] in steps of 0.1 and the value
maximising mean F1 across the validation set is returned.

`get_or_compute_threshold(model_path)` wraps `gridsearch` with file-based
caching: the result is written to
`<model_path_without_extension>_threshold.json` after the first run and loaded
from there on every subsequent call. `synapse_detection_from_prediction` accepts
an optional `threshold` parameter; when omitted it calls
`get_or_compute_threshold(model_path)` automatically.