### PR TITLE
Sgn density

### DIFF
--- a/doc/sgn_density.md
+++ b/doc/sgn_density.md
@@ -1,0 +1,57 @@
+# Analysing SGN density
+
+An important parameter for analyzing SGN survivability is the SGN density. Usually it is either given as a cell density per area [mm²] or per volume [mm³].
+The following examples show how
+
+## Calculate SGN density
+
+The density of an SGN segmentation can be calculated using `flamingo_tools.sgn_density`
+The process requires the segmentation table, which is usually located at `<cochlea-name>/tables/<SGN-version>/default.tsv` in a MoBIE project. It requires tonotopic mapping because reference points are derived from the run length of the Rosenthal's canal.
+
+Some examples for cochlea `M_LR_000155_L`:
+```bash
+# 2D slices with 10 µm thickness, at apex, mid and base
+flamingo_tools.sgn_density -i M_LR_000155_L/tables/SGN_v2/default.tsv -o SGN_density.json --slice_thickness 10 \
+    --json_input MLR155L_metadata.json --json_output MLR155L_crop_2d.json \
+    --mode 2d --min_overlap_fraction 0.2 --seg_path M_LR_000155_L/images/ome-zarr/SGN_v2.ome.zarr --s3
+
+# 3D volume with 120 µm thickness
+flamingo_tools.sgn_density -i M_LR_000155_L/tables/SGN_v2/default.tsv -o SGN_density.json --slice_thickness 120 \
+    --json_input MLR155L_metadata.json --json_output MLR155L_crop_3d.json \
+    --mode 3d --min_overlap_fraction 0.2 --seg_path M_LR_000155_L/images/ome-zarr/SGN_v2.ome.zarr --s3
+```
+
+where the parameters:
+- `--slice_thickness` refer to the thickness in z-dimension in µm
+- `MLR155L_metadata.json`, the argument for ``--json_input` refers to a JSON file containing metadata, e.g.
+```JSON
+    {
+        "dataset_name": "M_LR_000155_L",
+        "image_channel": [
+                "PV",
+                "GFP",
+                "SGN_v2"
+        ],
+        "segmentation_channel": "SGN_v2",
+        "component_list": [
+                1
+        ]
+}
+```
+specifying the image channels, the relevant segmentation channel, and the component list
+- `--mode` can either be 2d or 3d, depending on the desired density output
+- `--min_overlap_fraction` signifies the limit for the fraction of an SGN instance which is inside the crop used for density estimation. If the fraction is lower than this value, the SGN is omitted from the calculation. In the examples, SGNs which have less than 20% of their entire volume inside the crop will be excluded from the calculation
+- `--json_output` is a JSON dictionary which contains crop centers and ROI halos which can be used as input for `flamingo_tools.extract_block` as the `--json_info` argument to crop the subvolumes
+- `--positions` can be used to evaluate the SGN density at specific length fractions of Rosenthal's canal, default values are apex (0.15), mid (0.5) and base (0.85)
+- additional parameters are explained in the function documentation (`flamingo_tools.sgn_density -h`)
+
+
+## Crop slices/volumes used for density calculation
+
+The crops used for density calculation can be cropped using `flamingo_tools.extract_block`:
+
+```bash
+# crop data on S3 bucket
+flamingo_tools.extract_block --s3 --json_info MLR155L_crop_2d.json -o /path/to/output_crops
+```
+They can then also be used for the calculation of the SGN density by providing them as the `--seg_path` argument.

--- a/flamingo_tools/analysis/density_utils.py
+++ b/flamingo_tools/analysis/density_utils.py
@@ -262,15 +262,26 @@ def _auto_roi_halo(
     bb_min: List[float],
     bb_max: List[float],
     voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
-    min_halo: int = 16,
+    axis: str = "z",
+    slice_thickness: Optional[float] = None,
+    min_halo: int = 10,
 ) -> List[int]:
-    """Compute roi_halo in pixels that covers the bounding box half-extents.
+    """Compute roi_halo in pixels sized to match the slice exactly.
+
+    Along the slice axis the halo is derived from slice_thickness / 2 so the
+    extracted block matches the slice used for the density calculation.
+    Along the two projection axes the bounding box half-extents are used.
 
     Args:
-        bb_min: [x, y, z] lower corner of the bounding box in µm.
-        bb_max: [x, y, z] upper corner of the bounding box in µm.
+        bb_min: [x, y, z] lower corner of the SGN bounding box in µm.
+        bb_max: [x, y, z] upper corner of the SGN bounding box in µm.
         voxel_size: Voxel size in µm per axis (default 0.38 µm isotropic).
-        min_halo: Minimum halo size in pixels (default 16).
+        axis: Axis that was perpendicular to the slice plane ('x', 'y', or 'z').
+        slice_thickness: Slice thickness in µm used for the density calculation.
+                         When provided, the halo along ``axis`` is set to
+                         ceil(slice_thickness / 2 / voxel_size); otherwise the
+                         bounding box extent is used for all axes.
+        min_halo: Minimum halo size in pixels per axis (default 10).
 
     Returns:
         List of 3 ints [halo_x, halo_y, halo_z] in pixels.
@@ -278,9 +289,13 @@ def _auto_roi_halo(
     import math
     if any(np.isnan(v) for v in list(bb_min) + list(bb_max)):
         return [128, 128, 64]
+    axis_index = {"x": 0, "y": 1, "z": 2}[axis]
     halo = []
-    for lo, hi, vs in zip(bb_min, bb_max, voxel_size):
-        half_px = math.ceil((hi - lo) / 2.0 / vs)
+    for i, (lo, hi, vs) in enumerate(zip(bb_min, bb_max, voxel_size)):
+        if i == axis_index and slice_thickness is not None:
+            half_px = math.ceil(slice_thickness / 2.0 / vs)
+        else:
+            half_px = math.ceil((hi - lo) / 2.0 / vs)
         halo.append(max(min_halo, half_px))
     return halo
 
@@ -300,7 +315,10 @@ def _build_block_extraction_dict(
     roi_halo priority per entry:
         1. Explicit ``roi_halo`` argument (same value applied to all positions).
         2. ``roi_halo`` key from ``input_json_params`` (same for all positions).
-        3. Auto-computed from the position's 3D bounding box and ``voxel_size``.
+        3. Auto-computed: slice_thickness / 2 along the slice axis; bounding box
+           half-extents along the two projection axes. Both are converted to pixels
+           using ``voxel_size``. The axis and slice_thickness are read from each
+           position's density result.
 
     Args:
         density_results: Output of sgn_density_profile — dict keyed by position label.
@@ -340,7 +358,11 @@ def _build_block_extraction_dict(
         else:
             bb_min = pos_result.get("bb_min", [float("nan")] * 3)
             bb_max = pos_result.get("bb_max", [float("nan")] * 3)
-            entry["roi_halo"] = _auto_roi_halo(bb_min, bb_max, voxel_size)
+            entry["roi_halo"] = _auto_roi_halo(
+                bb_min, bb_max, voxel_size,
+                axis=pos_result.get("axis", "z"),
+                slice_thickness=pos_result.get("slice_thickness"),
+            )
 
         result_list.append(entry)
 

--- a/flamingo_tools/analysis/density_utils.py
+++ b/flamingo_tools/analysis/density_utils.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -24,19 +24,19 @@ _AXIS_PROJECTION = {
 def sgn_density_at_position(
     table: pd.DataFrame,
     reference_position: Union[float, str] = "mid",
-    slice_thickness: float = 40.0,
+    slice_thickness: float = 10.0,
     run_length_tolerance: float = 0.1,
     component_label: int = 1,
     axis: str = "z",
     length_fraction_column: str = "length_fraction",
+    mode: str = "2d",
 ) -> dict:
     """Calculate SGN density at a specific cochlear position using a planar slice.
 
     Selects all SGN instances whose bounding boxes overlap a slice of given thickness
     centered on the reference position, then removes instances whose run-length fraction
     differs too much from the reference (handles oblique cochlear orientation). Density
-    is computed as count / convex-hull area of the selected anchor points projected onto
-    the plane perpendicular to `axis`.
+    is computed as count / convex-hull area (2D mode) or convex-hull volume (3D mode).
 
     Args:
         table: SGN segmentation table with columns anchor_{x,y,z}, bb_min/max_{x,y,z},
@@ -45,13 +45,17 @@ def sgn_density_at_position(
                tonotopic mapping so that the length_fraction column is present.
         reference_position: Anatomical preset ('apex' → 0.15, 'mid' → 0.5, 'base' → 0.85)
                             or a custom float in [0, 1].
-        slice_thickness: Total slice thickness in µm (default 40 µm).
+        slice_thickness: Total slice thickness in µm (default 10 µm).
         run_length_tolerance: Max abs difference in length_fraction allowed for inclusion.
                               Instances outside this window are excluded to filter out
                               other cochlear turns passing through the same z-range.
         component_label: Component label of the main RC component (default 1).
         axis: Volume axis perpendicular to the slice plane ('x', 'y', or 'z'; default 'z').
         length_fraction_column: Column name for the run-length fraction (default 'length_fraction').
+        mode: Density mode. '2d' (default) projects anchor points onto the plane perpendicular
+              to `axis` and computes density per area (SGN/µm²). '3d' uses the full 3D convex
+              hull of all anchor points and computes density per volume (SGN/µm³); a larger
+              slice_thickness is recommended in this mode.
 
     Returns:
         dict with keys:
@@ -60,9 +64,12 @@ def sgn_density_at_position(
             slice_center        - anchor coordinate along `axis` for the reference (µm)
             slice_min           - lower bound of the slice window (µm)
             slice_max           - upper bound of the slice window (µm)
+            slice_thickness     - slice thickness used (µm)
             n_sgns              - number of SGNs counted in the slice
-            area_µm²            - cross-sectional area from convex hull (µm²)
-            density_µm⁻²       - n_sgns / area_µm²
+            area                - convex-hull cross-sectional area (µm²); only in mode='2d'
+            volume              - convex-hull volume (µm³); only in mode='3d'
+            density             - n_sgns / area (mode='2d') or n_sgns / volume (mode='3d')
+            mode                - density mode used ('2d' or '3d')
             axis                - axis used for slicing
             bb_min              - [x, y, z] lower corner of 3D bounding box (µm)
             bb_max              - [x, y, z] upper corner of 3D bounding box (µm)
@@ -71,6 +78,8 @@ def sgn_density_at_position(
     """
     if axis not in _AXIS_PROJECTION:
         raise ValueError(f"axis must be one of {list(_AXIS_PROJECTION)}, got '{axis}'")
+    if mode not in ("2d", "3d"):
+        raise ValueError(f"mode must be '2d' or '3d', got '{mode}'")
 
     # Validate required columns.
     required_cols = (
@@ -123,12 +132,17 @@ def sgn_density_at_position(
 
     n_sgns = len(in_slice)
 
-    # Compute cross-sectional area via convex hull.
-    proj_axes = _AXIS_PROJECTION[axis]
-    coords_2d = in_slice[[f"anchor_{a}" for a in proj_axes]].values
+    # Compute extent (area in 2D, volume in 3D) via convex hull.
+    if mode == "2d":
+        proj_axes = _AXIS_PROJECTION[axis]
+        hull_coords = in_slice[[f"anchor_{a}" for a in proj_axes]].values
+        extent_key = "area"
+    else:
+        hull_coords = in_slice[["anchor_x", "anchor_y", "anchor_z"]].values
+        extent_key = "volume"
 
-    area = _compute_area(coords_2d)
-    density = n_sgns / area if area > 0 else float("nan")
+    extent = _compute_hull_extent(hull_coords)
+    density = n_sgns / extent if extent > 0 else float("nan")
 
     # 3D bounding box covering all selected SGN instance bounding boxes.
     if n_sgns > 0:
@@ -152,9 +166,11 @@ def sgn_density_at_position(
         "slice_center": slice_center,
         "slice_min": slice_min,
         "slice_max": slice_max,
+        "slice_thickness": slice_thickness,
         "n_sgns": n_sgns,
-        "area_µm²": area,
-        "density_µm⁻²": density,
+        extent_key: extent,
+        "density": density,
+        "mode": mode,
         "axis": axis,
         "bb_min": bb_min,
         "bb_max": bb_max,
@@ -162,42 +178,49 @@ def sgn_density_at_position(
     }
 
 
-def _compute_area(coords_2d: np.ndarray) -> float:
-    """Return convex hull area of 2D points; falls back to bounding rectangle for < 3 points."""
-    if len(coords_2d) == 0:
-        warnings.warn("No SGN instances in slice; area is 0.", stacklevel=3)
+def _compute_hull_extent(coords: np.ndarray) -> float:
+    """Return convex hull area (2D input) or volume (3D input); falls back to bounding box."""
+    if len(coords) == 0:
+        warnings.warn("No SGN instances in slice; extent is 0.", stacklevel=3)
         return 0.0
 
-    if len(coords_2d) < 3:
+    ndim = coords.shape[1]
+    min_pts = ndim + 1  # 3 for 2D, 4 for 3D
+    if len(coords) < min_pts:
         warnings.warn(
-            f"Only {len(coords_2d)} SGN instance(s) in slice; falling back to bounding-rectangle area.",
+            f"Only {len(coords)} SGN instance(s) in slice; falling back to bounding-box extent.",
             stacklevel=3,
         )
-        return _bbox_area(coords_2d)
+        return _bbox_extent(coords)
 
     try:
-        hull = ConvexHull(coords_2d)
-        return float(hull.volume)  # For 2D input, hull.volume is the area.
+        hull = ConvexHull(coords)
+        return float(hull.volume)  # area for 2D input, volume for 3D input
     except Exception:
-        warnings.warn("ConvexHull failed; falling back to bounding-rectangle area.", stacklevel=3)
-        return _bbox_area(coords_2d)
+        warnings.warn("ConvexHull failed; falling back to bounding-box extent.", stacklevel=3)
+        return _bbox_extent(coords)
 
 
-def _bbox_area(coords_2d: np.ndarray) -> float:
-    if len(coords_2d) == 0:
+def _bbox_extent(coords: np.ndarray) -> float:
+    """Product of axis ranges — area for 2D, volume for 3D."""
+    if len(coords) == 0:
         return 0.0
-    ranges = coords_2d.max(axis=0) - coords_2d.min(axis=0)
-    return float(ranges[0] * ranges[1])
+    ranges = coords.max(axis=0) - coords.min(axis=0)
+    result = 1.0
+    for r in ranges:
+        result *= float(r)
+    return result
 
 
 def sgn_density_profile(
     table: pd.DataFrame,
     positions: Optional[List[Union[float, str]]] = None,
-    slice_thickness: float = 40.0,
+    slice_thickness: float = 10.0,
     run_length_tolerance: float = 0.1,
     component_label: int = 1,
     axis: str = "z",
     length_fraction_column: str = "length_fraction",
+    mode: str = "2d",
 ) -> dict:
     """Compute SGN density at multiple cochlear positions.
 
@@ -205,11 +228,12 @@ def sgn_density_profile(
         table: SGN segmentation table (see sgn_density_at_position for required columns).
         positions: List of positions to evaluate. Each entry is either a preset string
                    ('apex', 'mid', 'base') or a float in [0, 1]. Default: ['apex', 'mid', 'base'].
-        slice_thickness: Total slice thickness in µm (default 40 µm).
+        slice_thickness: Total slice thickness in µm (default 10 µm).
         run_length_tolerance: Max abs difference in length_fraction for inclusion (default 0.1).
         component_label: Component label of the main RC component (default 1).
         axis: Volume axis perpendicular to the slice plane (default 'z').
         length_fraction_column: Column name for the run-length fraction (default 'length_fraction').
+        mode: '2d' (default) or '3d' — see sgn_density_at_position.
 
     Returns:
         dict keyed by position label (preset name or string-formatted float), each value
@@ -229,5 +253,95 @@ def sgn_density_profile(
             component_label=component_label,
             axis=axis,
             length_fraction_column=length_fraction_column,
+            mode=mode,
         )
     return results
+
+
+def _auto_roi_halo(
+    bb_min: List[float],
+    bb_max: List[float],
+    voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
+    min_halo: int = 16,
+) -> List[int]:
+    """Compute roi_halo in pixels that covers the bounding box half-extents.
+
+    Args:
+        bb_min: [x, y, z] lower corner of the bounding box in µm.
+        bb_max: [x, y, z] upper corner of the bounding box in µm.
+        voxel_size: Voxel size in µm per axis (default 0.38 µm isotropic).
+        min_halo: Minimum halo size in pixels (default 16).
+
+    Returns:
+        List of 3 ints [halo_x, halo_y, halo_z] in pixels.
+    """
+    import math
+    if any(np.isnan(v) for v in list(bb_min) + list(bb_max)):
+        return [128, 128, 64]
+    halo = []
+    for lo, hi, vs in zip(bb_min, bb_max, voxel_size):
+        half_px = math.ceil((hi - lo) / 2.0 / vs)
+        halo.append(max(min_halo, half_px))
+    return halo
+
+
+def _build_block_extraction_dict(
+    density_results: dict,
+    input_json_params: Optional[dict] = None,
+    roi_halo: Optional[List[int]] = None,
+    voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
+) -> List[dict]:
+    """Build a block-extraction JSON list compatible with flamingo_tools.extract_block --json_info.
+
+    Returns a list of dicts, one per evaluated position. Each dict contains a single
+    crop_center (the bb_center of that position, rounded to ints) and its own roi_halo
+    so that differently-sized ROIs can be extracted per position in one pass.
+
+    roi_halo priority per entry:
+        1. Explicit ``roi_halo`` argument (same value applied to all positions).
+        2. ``roi_halo`` key from ``input_json_params`` (same for all positions).
+        3. Auto-computed from the position's 3D bounding box and ``voxel_size``.
+
+    Args:
+        density_results: Output of sgn_density_profile — dict keyed by position label.
+        input_json_params: Optional dict from a ChReef-format input JSON, providing
+                           dataset_name, image_channel, segmentation_channel, roi_halo, etc.
+        roi_halo: Explicit ROI halo in pixels [x, y, z] applied to all positions.
+        voxel_size: Voxel size in µm per axis used for auto roi_halo computation.
+
+    Returns:
+        List of dicts, each compatible with flamingo_tools.extract_block --json_info.
+        The list can be used directly as the JSON input for extract_block_json_wrapper.
+    """
+    # Metadata shared by all positions.
+    common: dict = {}
+    if input_json_params is not None:
+        for key in ("dataset_name", "image_channel", "segmentation_channel", "cell_type", "component_list"):
+            if key in input_json_params:
+                common[key] = input_json_params[key]
+
+    # Explicit or JSON-level fallback halo (None means auto-compute per position).
+    global_halo: Optional[List[int]] = None
+    if roi_halo is not None:
+        global_halo = list(roi_halo)
+    elif input_json_params is not None and "roi_halo" in input_json_params:
+        global_halo = list(input_json_params["roi_halo"])
+
+    result_list: List[dict] = []
+    for position_label, pos_result in density_results.items():
+        entry = dict(common)
+        entry["position_label"] = position_label
+
+        center = pos_result.get("bb_center", [float("nan")] * 3)
+        entry["crop_centers"] = [[round(c) for c in center]]
+
+        if global_halo is not None:
+            entry["roi_halo"] = global_halo
+        else:
+            bb_min = pos_result.get("bb_min", [float("nan")] * 3)
+            bb_max = pos_result.get("bb_max", [float("nan")] * 3)
+            entry["roi_halo"] = _auto_roi_halo(bb_min, bb_max, voxel_size)
+
+        result_list.append(entry)
+
+    return result_list

--- a/flamingo_tools/analysis/density_utils.py
+++ b/flamingo_tools/analysis/density_utils.py
@@ -1,4 +1,6 @@
+import json
 import math
+import os
 import warnings
 from typing import List, Optional, Tuple, Union
 
@@ -8,6 +10,9 @@ from scipy.spatial import ConvexHull
 from skimage.measure import regionprops
 
 from flamingo_tools.analysis.seg_table_utils import filter_table
+from flamingo_tools.file_utils import read_image_data
+from flamingo_tools.s3_utils import MOBIE_FOLDER, get_s3_path
+from flamingo_tools.json_util import export_dictionary_as_json
 
 REFERENCE_PRESETS = {
     "apex": 0.15,
@@ -31,14 +36,13 @@ def sgn_density_at_position(
     reference_position: Union[float, str] = "mid",
     slice_thickness: float = 10.0,
     run_length_tolerance: float = 0.1,
-    component_label: int = 1,
+    component_list: List[int] = [1],
     axis: str = "z",
     length_fraction_column: str = "length_fraction",
     mode: str = "2d",
     segmentation=None,
     voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
     min_overlap_fraction: Optional[float] = None,
-    seg_offset: Tuple[float, float, float] = (0.0, 0.0, 0.0),
 ) -> dict:
     """Calculate SGN density at a specific cochlear position using a planar slice.
 
@@ -58,7 +62,7 @@ def sgn_density_at_position(
         run_length_tolerance: Max abs difference in length_fraction allowed for inclusion.
                               Instances outside this window are excluded to filter out
                               other cochlear turns passing through the same z-range.
-        component_label: Component label of the main RC component (default 1).
+        component_list: Component label(s) of the main RC component (default 1).
         axis: Volume axis perpendicular to the slice plane ('x', 'y', or 'z'; default 'z').
         length_fraction_column: Column name for the run-length fraction (default 'length_fraction').
         mode: Density mode. '2d' (default) projects anchor points onto the plane perpendicular
@@ -76,10 +80,6 @@ def sgn_density_at_position(
                               must lie within the slice for the instance to be counted. Only
                               active when `segmentation` is also provided. Default None
                               (no segmentation-based filtering).
-        seg_offset: Physical coordinates (µm) of pixel (0, 0, 0) of the segmentation array,
-                    in (x, y, z) order. Use (0, 0, 0) for a full OME-ZARR volume; set to
-                    the crop origin when `segmentation` is a pre-extracted sub-volume.
-
     Returns:
         dict with keys:
             reference_fraction  - resolved fraction used as the target position
@@ -130,9 +130,9 @@ def sgn_density_at_position(
             raise ValueError(f"reference_position float must be in [0, 1], got {ref_frac}")
 
     # Filter to main component.
-    comp_table = filter_table(table, column_subset=[component_label], column="component_labels")
+    comp_table = filter_table(table, column_subset=component_list, column="component_labels")
     if comp_table.empty:
-        raise ValueError(f"No rows found for component_label={component_label}")
+        raise ValueError(f"No rows found for component_list={component_list}")
 
     # Find the SGN instance closest to the reference fraction.
     frac_diff = (comp_table[length_fraction_column] - ref_frac).abs()
@@ -158,7 +158,7 @@ def sgn_density_at_position(
     if segmentation is not None and min_overlap_fraction is not None:
         in_slice = _filter_by_segmentation_overlap(
             in_slice, segmentation, slice_min, slice_max,
-            axis, voxel_size, seg_offset, min_overlap_fraction,
+            axis, voxel_size, min_overlap_fraction,
         )
 
     n_sgns = len(in_slice)
@@ -251,14 +251,19 @@ def _filter_by_segmentation_overlap(
     slice_max: float,
     axis: str,
     voxel_size: Tuple[float, float, float],
-    seg_offset: Tuple[float, float, float],
     min_overlap_fraction: float,
 ) -> pd.DataFrame:
     """Filter SGN instances by their voxel overlap with the slice sub-volume.
 
-    Loads the slice slab from `segmentation` (a zarr array or numpy array in (Z, Y, X)
-    order), counts how many voxels of each label_id fall inside, and keeps only rows
-    where `voxels_in_slice / n_pixels >= min_overlap_fraction`.
+    Loads a slab from `segmentation` (a zarr array or numpy array in (Z, Y, X) order),
+    counts how many voxels of each label_id fall inside, and keeps only rows where
+    `voxels_in_slice / n_pixels >= min_overlap_fraction`.
+
+    The function auto-detects whether `segmentation` is a full volume or a pre-extracted
+    crop by comparing its physical extent (shape × voxel_size) along the slice axis to the
+    maximum anchor coordinate in `table`. When the physical extent is smaller than the
+    maximum anchor coordinate the array is treated as a crop and used in full; otherwise
+    the appropriate slab is extracted with offset 0.
 
     Args:
         table: SGN table (already reduced to candidate instances).
@@ -267,7 +272,6 @@ def _filter_by_segmentation_overlap(
         slice_max: Upper bound of the slice in µm along `axis`.
         axis: Physical axis name ('x', 'y', or 'z') used for slicing.
         voxel_size: Voxel size in µm per axis (x, y, z order).
-        seg_offset: Physical origin of seg[0,0,0] in µm (x, y, z order).
         min_overlap_fraction: Minimum overlap fraction for inclusion.
 
     Returns:
@@ -276,16 +280,21 @@ def _filter_by_segmentation_overlap(
     # Map physical axis (x/y/z) to its index in the (x,y,z) tuple and to zarr dim (Z,Y,X).
     phys_index = {"x": 0, "y": 1, "z": 2}[axis]
     dim = _AXIS_ZYX_DIM[axis]
-
-    offset_a = seg_offset[phys_index]
     vs_a = voxel_size[phys_index]
 
-    px_start = max(0, math.floor((slice_min - offset_a) / vs_a))
-    px_end = min(segmentation.shape[dim], math.ceil((slice_max - offset_a) / vs_a) + 1)
-
-    idx = [slice(None)] * 3
-    idx[dim] = slice(px_start, px_end)
-    sub_vol = np.asarray(segmentation[tuple(idx)])
+    # Auto-detect crop vs. full volume: if the array's physical extent along the slice axis
+    # is smaller than the maximum anchor coordinate in the table, the array is a crop and
+    # all of its voxels are already within the region of interest.
+    seg_physical_extent = segmentation.shape[dim] * vs_a
+    max_anchor = float(table[f"anchor_{axis}"].max())
+    if max_anchor > seg_physical_extent:
+        sub_vol = np.asarray(segmentation)
+    else:
+        px_start = max(0, math.floor(slice_min / vs_a))
+        px_end = min(segmentation.shape[dim], math.ceil(slice_max / vs_a) + 1)
+        idx = [slice(None)] * 3
+        idx[dim] = slice(px_start, px_end)
+        sub_vol = np.asarray(segmentation[tuple(idx)])
 
     # Count voxels per label in the sub-volume using regionprops (efficient label scan).
     voxels_in_slice = {prop.label: prop.area for prop in regionprops(sub_vol)}
@@ -308,14 +317,13 @@ def sgn_density_profile(
     positions: Optional[List[Union[float, str]]] = None,
     slice_thickness: float = 10.0,
     run_length_tolerance: float = 0.1,
-    component_label: int = 1,
+    component_list: List[int] = [1],
     axis: str = "z",
     length_fraction_column: str = "length_fraction",
     mode: str = "2d",
     segmentation=None,
     voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
     min_overlap_fraction: Optional[float] = None,
-    seg_offset: Tuple[float, float, float] = (0.0, 0.0, 0.0),
 ) -> dict:
     """Compute SGN density at multiple cochlear positions.
 
@@ -325,14 +333,13 @@ def sgn_density_profile(
                    ('apex', 'mid', 'base') or a float in [0, 1]. Default: ['apex', 'mid', 'base'].
         slice_thickness: Total slice thickness in µm (default 10 µm).
         run_length_tolerance: Max abs difference in length_fraction for inclusion (default 0.1).
-        component_label: Component label of the main RC component (default 1).
+        component_list: Component label(s) of the main RC component (default 1).
         axis: Volume axis perpendicular to the slice plane (default 'z').
         length_fraction_column: Column name for the run-length fraction (default 'length_fraction').
         mode: '2d' (default) or '3d' — see sgn_density_at_position.
         segmentation: Optional segmentation array (Z, Y, X) — see sgn_density_at_position.
         voxel_size: Voxel size in µm per axis (x, y, z order; default 0.38 µm isotropic).
         min_overlap_fraction: Minimum voxel overlap fraction — see sgn_density_at_position.
-        seg_offset: Physical origin of seg[0,0,0] in µm (x, y, z order; default (0,0,0)).
 
     Returns:
         dict keyed by position label (preset name or string-formatted float), each value
@@ -349,14 +356,13 @@ def sgn_density_profile(
             reference_position=pos,
             slice_thickness=slice_thickness,
             run_length_tolerance=run_length_tolerance,
-            component_label=component_label,
+            component_list=component_list,
             axis=axis,
             length_fraction_column=length_fraction_column,
             mode=mode,
             segmentation=segmentation,
             voxel_size=voxel_size,
             min_overlap_fraction=min_overlap_fraction,
-            seg_offset=seg_offset,
         )
     return results
 
@@ -470,3 +476,166 @@ def _build_block_extraction_dict(
         result_list.append(entry)
 
     return result_list
+
+
+def calc_sgn_density(
+    output: str,
+    seg_table_path: Optional[str] = None,
+    json_input: Optional[str] = None,
+    json_output: Optional[str] = None,
+    force_overwrite: bool = False,
+    positions: List[Union[str, float]] = ["apex", "mid", "base"],
+    slice_thickness: float = 10.0,
+    run_length_tolerance: float = 0.1,
+    component_list: List[int] = [1],
+    axis: str = "z",
+    length_fraction_column: str = "length_fraction",
+    density_mode: str = "2d",
+    roi_halo: Optional[List[int]] = None,
+    voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
+    mobie_dir: str = MOBIE_FOLDER,
+    seg_path: Optional[str] = None,
+    seg_key: str = "s0",
+    min_overlap_fraction: Optional[float] = None,
+    s3: bool = False,
+    s3_credentials: Optional[str] = None,
+    s3_bucket_name: Optional[str] = None,
+    s3_service_endpoint: Optional[str] = None,
+):
+    """
+
+    Args:
+        output: Output path for JSON file with density results.
+        seg_table_path: Input path to SGN segmentation table (TSV). Must contain length_fraction column
+                        (produced by flamingo_tools.tonotopic_mapping).
+                        Optional when --json_input is supplied.
+        json_input: Input JSON file with metadata information(dataset_name, image_channel,
+                         segmentation_channel, …). When 'seg_table_path' is absent the table path
+                         is derived from dataset_name and segmentation_channel via 'mobie_dir'.
+        json_output: Optional output path for block-extraction JSON compatible with
+                     flamingo_tools.extract_block --json_info.
+                     Contains crop_centers derived from the density bounding boxes.
+        force_overwrite: Forcefully overwrite output.
+        positions: Cochlear positions to evaluate. Use preset names ('apex', 'mid', 'base') or
+                   floats in [0, 1]. Default: apex mid base
+        slice_thickness: Total thickness of the horizontal slice in µm. Default: 10.0
+        run_length_tolerance: Maximum allowed length_fraction difference to include an SGN instance.
+                              Reduces contamination from other cochlear turns. Default: 0.1
+        component_list: Component label(s) of the main Rosenthal's Canal component. Default: 1
+        axis: Volume axis perpendicular to the slice plane. Default: z
+        length_fraction_column: Column name for the run-length fraction in the table. Default: length_fraction.
+        density_mode: Density mode: '2d' computes density per cross-sectional area (SGN/µm²);
+                      '3d' computes density per convex-hull volume (SGN/µm³). Default: 2d
+        roi_halo: ROI halo in pixels [x y z] for the block-extraction JSON output, applied to all
+                  positions. Overrides the value from 'json_input'.
+                  If omitted, the halo is computed automatically from each position's bounding box.
+        voxel_size: Voxel size in µm used to convert bounding box extents to pixels when
+                    computing the automatic roi_halo. Provide 1 value (isotropic) or 3 values (x y z).
+        mobie_dir: Local MoBIE project directory used to locate the table when 'json_input' is given
+                   and 'seg_table_path' is absent.
+        seg_path: Path to the SGN segmentation volume (local TIF, N5/Zarr, or S3 OME-ZARR).
+                  When omitted and 'json_input' is given, the path is derived automatically as
+                  <dataset_name>/images/ome-zarr/<segmentation_channel>.ome.zarr.
+                  Only used when 'min_overlap_fraction' is set.
+        seg_key: Internal key for N5/Zarr/OME-ZARR segmentation (default: s0).
+        min_overlap_fraction: Minimum fraction of an SGN's voxels (n_pixels) that must lie within the
+                              slice sub-volume to count the instance. Range (0, 1].
+                              Default: None (no segmentation-based filtering). Whether the
+                              segmentation is a pre-extracted crop or a full volume is detected
+                              automatically from the array shape.
+        s3: Flag for accessing data stored on S3 bucket.
+        s3_credentials: File path to credentials for S3 bucket.
+        s3_bucket_name: S3 bucket name.
+        s3_service_endpoint: S3 service endpoint.
+    """
+    # Resolve table path and optional JSON metadata.
+    json_params = None
+    if json_input is not None:
+        with open(json_input) as f:
+            json_params = json.load(f)
+        if isinstance(json_params, list):
+            json_params = json_params[0]
+
+    if seg_table_path is not None:
+        table_path = seg_table_path
+    elif json_params is not None:
+        dataset_name = json_params["dataset_name"]
+        seg_channel = json_params.get("segmentation_channel", "SGN_v2")
+        if s3:
+            table_path = f"{dataset_name}/tables/{seg_channel}/default.tsv"
+        else:
+            table_path = os.path.join(mobie_dir, dataset_name, "tables", seg_channel, "default.tsv")
+    else:
+        raise ValueError("Provide 'seg_table_path' or 'json_input'.")
+
+    # Convert numeric position strings to floats.
+    positions_list = []
+    for p in positions:
+        try:
+            positions_list.append(float(p))
+        except ValueError:
+            positions_list.append(p)
+
+    if s3:
+        tsv_path, fs = get_s3_path(
+            table_path,
+            credential_file=s3_credentials,
+            bucket_name=s3_bucket_name,
+            service_endpoint=s3_service_endpoint,
+        )
+        with fs.open(tsv_path, "r") as f:
+            table = pd.read_csv(f, sep="\t")
+    else:
+        table = pd.read_csv(table_path, sep="\t")
+
+    # Resolve voxel size.
+    if len(voxel_size) == 1:
+        voxel_size = voxel_size * 3
+    voxel_size = tuple(voxel_size)
+
+    # Resolve and load segmentation if overlap filtering is requested.
+    segmentation = None
+    if min_overlap_fraction is not None:
+        if seg_path is None and json_params is not None:
+            dataset_name = json_params["dataset_name"]
+            seg_channel = json_params.get("segmentation_channel", "SGN_v2")
+            if s3:
+                seg_path = f"{dataset_name}/images/ome-zarr/{seg_channel}.ome.zarr"
+            else:
+                seg_path = os.path.join(
+                    mobie_dir, dataset_name, "images", "ome-zarr",
+                    f"{seg_channel}.ome.zarr",
+                )
+        if seg_path is not None:
+            segmentation = read_image_data(
+                seg_path, seg_key,
+                from_s3=s3,
+                credential_file=s3_credentials,
+                bucket_name=s3_bucket_name,
+                service_endpoint=s3_service_endpoint,
+            )
+
+    results = sgn_density_profile(
+        table,
+        positions=positions_list,
+        slice_thickness=slice_thickness,
+        run_length_tolerance=run_length_tolerance,
+        component_list=component_list,
+        axis=axis,
+        length_fraction_column=length_fraction_column,
+        mode=density_mode,
+        segmentation=segmentation,
+        voxel_size=voxel_size,
+        min_overlap_fraction=min_overlap_fraction,
+    )
+
+    export_dictionary_as_json(results, output, force_overwrite=force_overwrite)
+
+    if json_output is not None:
+        block_list = _build_block_extraction_dict(
+            results,
+            input_json_params=json_params,
+            roi_halo=roi_halo,
+            voxel_size=voxel_size,
+        )
+        export_dictionary_as_json(block_list, json_output, force_overwrite=force_overwrite)

--- a/flamingo_tools/analysis/density_utils.py
+++ b/flamingo_tools/analysis/density_utils.py
@@ -1,0 +1,167 @@
+import warnings
+from typing import Union
+
+import numpy as np
+import pandas as pd
+from scipy.spatial import ConvexHull
+
+from flamingo_tools.analysis.seg_table_utils import filter_table
+
+REFERENCE_PRESETS = {
+    "apex": 0.15,
+    "mid": 0.5,
+    "base": 0.85,
+}
+
+# Maps the slice axis to the two axes of the projection plane used for area computation.
+_AXIS_PROJECTION = {
+    "z": ("x", "y"),
+    "y": ("x", "z"),
+    "x": ("y", "z"),
+}
+
+
+def sgn_density_at_position(
+    table: pd.DataFrame,
+    reference_position: Union[float, str] = "mid",
+    slice_thickness: float = 40.0,
+    run_length_tolerance: float = 0.1,
+    component_label: int = 1,
+    axis: str = "z",
+    length_fraction_column: str = "length_fraction",
+) -> dict:
+    """Calculate SGN density at a specific cochlear position using a planar slice.
+
+    Selects all SGN instances whose bounding boxes overlap a slice of given thickness
+    centered on the reference position, then removes instances whose run-length fraction
+    differs too much from the reference (handles oblique cochlear orientation). Density
+    is computed as count / convex-hull area of the selected anchor points projected onto
+    the plane perpendicular to `axis`.
+
+    Args:
+        table: SGN segmentation table with columns anchor_{x,y,z}, bb_min/max_{x,y,z},
+               component_labels, label_id, and the length_fraction column. Coordinates
+               must be in physical units (µm). The table is expected to have been through
+               tonotopic mapping so that the length_fraction column is present.
+        reference_position: Anatomical preset ('apex' → 0.15, 'mid' → 0.5, 'base' → 0.85)
+                            or a custom float in [0, 1].
+        slice_thickness: Total slice thickness in µm (default 40 µm).
+        run_length_tolerance: Max abs difference in length_fraction allowed for inclusion.
+                              Instances outside this window are excluded to filter out
+                              other cochlear turns passing through the same z-range.
+        component_label: Component label of the main RC component (default 1).
+        axis: Volume axis perpendicular to the slice plane ('x', 'y', or 'z'; default 'z').
+        length_fraction_column: Column name for the run-length fraction (default 'length_fraction').
+
+    Returns:
+        dict with keys:
+            reference_fraction  - resolved fraction used as the target position
+            reference_label_id  - label_id of the SGN instance nearest to that fraction
+            slice_center        - anchor coordinate along `axis` for the reference (µm)
+            slice_min           - lower bound of the slice window (µm)
+            slice_max           - upper bound of the slice window (µm)
+            n_sgns              - number of SGNs counted in the slice
+            area_µm²            - cross-sectional area from convex hull (µm²)
+            density_µm⁻²       - n_sgns / area_µm²
+            axis                - axis used for slicing
+    """
+    if axis not in _AXIS_PROJECTION:
+        raise ValueError(f"axis must be one of {list(_AXIS_PROJECTION)}, got '{axis}'")
+
+    # Validate required columns.
+    required_cols = (
+        ["label_id", "component_labels", length_fraction_column]
+        + [f"anchor_{a}" for a in ("x", "y", "z")]
+        + [f"bb_min_{a}" for a in ("x", "y", "z")]
+        + [f"bb_max_{a}" for a in ("x", "y", "z")]
+    )
+    missing = [c for c in required_cols if c not in table.columns]
+    if missing:
+        raise ValueError(f"Table is missing required columns: {missing}")
+
+    # Resolve reference fraction.
+    if isinstance(reference_position, str):
+        if reference_position not in REFERENCE_PRESETS:
+            raise ValueError(
+                f"reference_position string must be one of {list(REFERENCE_PRESETS)}, "
+                f"got '{reference_position}'"
+            )
+        ref_frac = REFERENCE_PRESETS[reference_position]
+    else:
+        ref_frac = float(reference_position)
+        if not (0.0 <= ref_frac <= 1.0):
+            raise ValueError(f"reference_position float must be in [0, 1], got {ref_frac}")
+
+    # Filter to main component.
+    comp_table = filter_table(table, column_subset=[component_label], column="component_labels")
+    if comp_table.empty:
+        raise ValueError(f"No rows found for component_label={component_label}")
+
+    # Find the SGN instance closest to the reference fraction.
+    frac_diff = (comp_table[length_fraction_column] - ref_frac).abs()
+    ref_row = comp_table.iloc[frac_diff.argmin()]
+    ref_label_id = int(ref_row["label_id"])
+    slice_center = float(ref_row[f"anchor_{axis}"])
+    slice_min = slice_center - slice_thickness / 2.0
+    slice_max = slice_center + slice_thickness / 2.0
+
+    # Select by bounding-box overlap with the slice.
+    bb_min_col = f"bb_min_{axis}"
+    bb_max_col = f"bb_max_{axis}"
+    in_slice = comp_table[
+        (comp_table[bb_min_col] <= slice_max) & (comp_table[bb_max_col] >= slice_min)
+    ]
+
+    # Filter by run-length proximity to exclude other cochlear turns.
+    in_slice = in_slice[
+        (in_slice[length_fraction_column] - ref_frac).abs() <= run_length_tolerance
+    ]
+
+    n_sgns = len(in_slice)
+
+    # Compute cross-sectional area via convex hull.
+    proj_axes = _AXIS_PROJECTION[axis]
+    coords_2d = in_slice[[f"anchor_{a}" for a in proj_axes]].values
+
+    area = _compute_area(coords_2d)
+    density = n_sgns / area if area > 0 else float("nan")
+
+    return {
+        "reference_fraction": ref_frac,
+        "reference_label_id": ref_label_id,
+        "slice_center": slice_center,
+        "slice_min": slice_min,
+        "slice_max": slice_max,
+        "n_sgns": n_sgns,
+        "area_µm²": area,
+        "density_µm⁻²": density,
+        "axis": axis,
+    }
+
+
+def _compute_area(coords_2d: np.ndarray) -> float:
+    """Return convex hull area of 2D points; falls back to bounding rectangle for < 3 points."""
+    if len(coords_2d) == 0:
+        warnings.warn("No SGN instances in slice; area is 0.", stacklevel=3)
+        return 0.0
+
+    if len(coords_2d) < 3:
+        warnings.warn(
+            f"Only {len(coords_2d)} SGN instance(s) in slice; falling back to bounding-rectangle area.",
+            stacklevel=3,
+        )
+        return _bbox_area(coords_2d)
+
+    try:
+        hull = ConvexHull(coords_2d)
+        return float(hull.volume)  # For 2D input, hull.volume is the area.
+    except Exception:
+        warnings.warn("ConvexHull failed; falling back to bounding-rectangle area.", stacklevel=3)
+        return _bbox_area(coords_2d)
+
+
+def _bbox_area(coords_2d: np.ndarray) -> float:
+    if len(coords_2d) == 0:
+        return 0.0
+    ranges = coords_2d.max(axis=0) - coords_2d.min(axis=0)
+    return float(ranges[0] * ranges[1])

--- a/flamingo_tools/analysis/density_utils.py
+++ b/flamingo_tools/analysis/density_utils.py
@@ -1,9 +1,11 @@
+import math
 import warnings
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
 from scipy.spatial import ConvexHull
+from skimage.measure import regionprops
 
 from flamingo_tools.analysis.seg_table_utils import filter_table
 
@@ -20,6 +22,9 @@ _AXIS_PROJECTION = {
     "x": ("y", "z"),
 }
 
+# Maps the physical axis name to the corresponding dimension index in a (Z, Y, X) array.
+_AXIS_ZYX_DIM = {"z": 0, "y": 1, "x": 2}
+
 
 def sgn_density_at_position(
     table: pd.DataFrame,
@@ -30,6 +35,10 @@ def sgn_density_at_position(
     axis: str = "z",
     length_fraction_column: str = "length_fraction",
     mode: str = "2d",
+    segmentation=None,
+    voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
+    min_overlap_fraction: Optional[float] = None,
+    seg_offset: Tuple[float, float, float] = (0.0, 0.0, 0.0),
 ) -> dict:
     """Calculate SGN density at a specific cochlear position using a planar slice.
 
@@ -56,6 +65,20 @@ def sgn_density_at_position(
               to `axis` and computes density per area (SGN/µm²). '3d' uses the full 3D convex
               hull of all anchor points and computes density per volume (SGN/µm³); a larger
               slice_thickness is recommended in this mode.
+        segmentation: Optional zarr array or numpy ndarray shaped (Z, Y, X) containing the
+                      SGN instance segmentation. When provided together with
+                      `min_overlap_fraction`, each candidate SGN is kept only if the fraction
+                      of its voxels that fall within the slice window meets the threshold.
+        voxel_size: Voxel size in µm per axis (x, y, z order; default 0.38 µm isotropic).
+                    Used to convert the physical slice window to pixel indices when
+                    `segmentation` is given.
+        min_overlap_fraction: Minimum fraction in (0, 1] of an SGN's voxels (`n_pixels`) that
+                              must lie within the slice for the instance to be counted. Only
+                              active when `segmentation` is also provided. Default None
+                              (no segmentation-based filtering).
+        seg_offset: Physical coordinates (µm) of pixel (0, 0, 0) of the segmentation array,
+                    in (x, y, z) order. Use (0, 0, 0) for a full OME-ZARR volume; set to
+                    the crop origin when `segmentation` is a pre-extracted sub-volume.
 
     Returns:
         dict with keys:
@@ -75,6 +98,7 @@ def sgn_density_at_position(
             bb_max              - [x, y, z] upper corner of 3D bounding box (µm)
             bb_center           - [x, y, z] center of 3D bounding box (µm); pass as `coords`
                                   to flamingo_tools.extract_block for block visualisation
+            min_overlap_fraction - value passed in (or None when not used)
     """
     if axis not in _AXIS_PROJECTION:
         raise ValueError(f"axis must be one of {list(_AXIS_PROJECTION)}, got '{axis}'")
@@ -83,10 +107,10 @@ def sgn_density_at_position(
 
     # Validate required columns.
     required_cols = (
-        ["label_id", "component_labels", length_fraction_column]
-        + [f"anchor_{a}" for a in ("x", "y", "z")]
-        + [f"bb_min_{a}" for a in ("x", "y", "z")]
-        + [f"bb_max_{a}" for a in ("x", "y", "z")]
+        ["label_id", "component_labels", length_fraction_column] +
+        [f"anchor_{a}" for a in ("x", "y", "z")] +
+        [f"bb_min_{a}" for a in ("x", "y", "z")] +
+        [f"bb_max_{a}" for a in ("x", "y", "z")]
     )
     missing = [c for c in required_cols if c not in table.columns]
     if missing:
@@ -129,6 +153,13 @@ def sgn_density_at_position(
     in_slice = in_slice[
         (in_slice[length_fraction_column] - ref_frac).abs() <= run_length_tolerance
     ]
+
+    # Optional: filter by actual voxel overlap with the slice sub-volume.
+    if segmentation is not None and min_overlap_fraction is not None:
+        in_slice = _filter_by_segmentation_overlap(
+            in_slice, segmentation, slice_min, slice_max,
+            axis, voxel_size, seg_offset, min_overlap_fraction,
+        )
 
     n_sgns = len(in_slice)
 
@@ -175,6 +206,7 @@ def sgn_density_at_position(
         "bb_min": bb_min,
         "bb_max": bb_max,
         "bb_center": bb_center,
+        "min_overlap_fraction": min_overlap_fraction,
     }
 
 
@@ -212,6 +244,65 @@ def _bbox_extent(coords: np.ndarray) -> float:
     return result
 
 
+def _filter_by_segmentation_overlap(
+    table: pd.DataFrame,
+    segmentation,
+    slice_min: float,
+    slice_max: float,
+    axis: str,
+    voxel_size: Tuple[float, float, float],
+    seg_offset: Tuple[float, float, float],
+    min_overlap_fraction: float,
+) -> pd.DataFrame:
+    """Filter SGN instances by their voxel overlap with the slice sub-volume.
+
+    Loads the slice slab from `segmentation` (a zarr array or numpy array in (Z, Y, X)
+    order), counts how many voxels of each label_id fall inside, and keeps only rows
+    where `voxels_in_slice / n_pixels >= min_overlap_fraction`.
+
+    Args:
+        table: SGN table (already reduced to candidate instances).
+        segmentation: Segmentation array shaped (Z, Y, X).
+        slice_min: Lower bound of the slice in µm along `axis`.
+        slice_max: Upper bound of the slice in µm along `axis`.
+        axis: Physical axis name ('x', 'y', or 'z') used for slicing.
+        voxel_size: Voxel size in µm per axis (x, y, z order).
+        seg_offset: Physical origin of seg[0,0,0] in µm (x, y, z order).
+        min_overlap_fraction: Minimum overlap fraction for inclusion.
+
+    Returns:
+        Filtered DataFrame.
+    """
+    # Map physical axis (x/y/z) to its index in the (x,y,z) tuple and to zarr dim (Z,Y,X).
+    phys_index = {"x": 0, "y": 1, "z": 2}[axis]
+    dim = _AXIS_ZYX_DIM[axis]
+
+    offset_a = seg_offset[phys_index]
+    vs_a = voxel_size[phys_index]
+
+    px_start = max(0, math.floor((slice_min - offset_a) / vs_a))
+    px_end = min(segmentation.shape[dim], math.ceil((slice_max - offset_a) / vs_a) + 1)
+
+    idx = [slice(None)] * 3
+    idx[dim] = slice(px_start, px_end)
+    sub_vol = np.asarray(segmentation[tuple(idx)])
+
+    # Count voxels per label in the sub-volume using regionprops (efficient label scan).
+    voxels_in_slice = {prop.label: prop.area for prop in regionprops(sub_vol)}
+
+    label_ids = table["label_id"].astype(int).values
+    n_pixels = table["n_pixels"].astype(int).values
+    vox_in_slice = np.array([voxels_in_slice.get(lid, 0) for lid in label_ids])
+    overlap = np.where(n_pixels > 0, vox_in_slice / n_pixels, 0.0)
+    filtered = table[overlap >= min_overlap_fraction]
+    if filtered.empty:
+        warnings.warn(
+            "All SGN instances were removed by the segmentation overlap filter.",
+            stacklevel=4,
+        )
+    return filtered
+
+
 def sgn_density_profile(
     table: pd.DataFrame,
     positions: Optional[List[Union[float, str]]] = None,
@@ -221,6 +312,10 @@ def sgn_density_profile(
     axis: str = "z",
     length_fraction_column: str = "length_fraction",
     mode: str = "2d",
+    segmentation=None,
+    voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
+    min_overlap_fraction: Optional[float] = None,
+    seg_offset: Tuple[float, float, float] = (0.0, 0.0, 0.0),
 ) -> dict:
     """Compute SGN density at multiple cochlear positions.
 
@@ -234,6 +329,10 @@ def sgn_density_profile(
         axis: Volume axis perpendicular to the slice plane (default 'z').
         length_fraction_column: Column name for the run-length fraction (default 'length_fraction').
         mode: '2d' (default) or '3d' — see sgn_density_at_position.
+        segmentation: Optional segmentation array (Z, Y, X) — see sgn_density_at_position.
+        voxel_size: Voxel size in µm per axis (x, y, z order; default 0.38 µm isotropic).
+        min_overlap_fraction: Minimum voxel overlap fraction — see sgn_density_at_position.
+        seg_offset: Physical origin of seg[0,0,0] in µm (x, y, z order; default (0,0,0)).
 
     Returns:
         dict keyed by position label (preset name or string-formatted float), each value
@@ -254,6 +353,10 @@ def sgn_density_profile(
             axis=axis,
             length_fraction_column=length_fraction_column,
             mode=mode,
+            segmentation=segmentation,
+            voxel_size=voxel_size,
+            min_overlap_fraction=min_overlap_fraction,
+            seg_offset=seg_offset,
         )
     return results
 

--- a/flamingo_tools/analysis/density_utils.py
+++ b/flamingo_tools/analysis/density_utils.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Union
+from typing import List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -64,6 +64,10 @@ def sgn_density_at_position(
             area_µm²            - cross-sectional area from convex hull (µm²)
             density_µm⁻²       - n_sgns / area_µm²
             axis                - axis used for slicing
+            bb_min              - [x, y, z] lower corner of 3D bounding box (µm)
+            bb_max              - [x, y, z] upper corner of 3D bounding box (µm)
+            bb_center           - [x, y, z] center of 3D bounding box (µm); pass as `coords`
+                                  to flamingo_tools.extract_block for block visualisation
     """
     if axis not in _AXIS_PROJECTION:
         raise ValueError(f"axis must be one of {list(_AXIS_PROJECTION)}, got '{axis}'")
@@ -126,6 +130,22 @@ def sgn_density_at_position(
     area = _compute_area(coords_2d)
     density = n_sgns / area if area > 0 else float("nan")
 
+    # 3D bounding box covering all selected SGN instance bounding boxes.
+    if n_sgns > 0:
+        bb_min = [
+            float(in_slice["bb_min_x"].min()),
+            float(in_slice["bb_min_y"].min()),
+            float(in_slice["bb_min_z"].min()),
+        ]
+        bb_max = [
+            float(in_slice["bb_max_x"].max()),
+            float(in_slice["bb_max_y"].max()),
+            float(in_slice["bb_max_z"].max()),
+        ]
+        bb_center = [(lo + hi) / 2.0 for lo, hi in zip(bb_min, bb_max)]
+    else:
+        bb_min = bb_max = bb_center = [float("nan"), float("nan"), float("nan")]
+
     return {
         "reference_fraction": ref_frac,
         "reference_label_id": ref_label_id,
@@ -136,6 +156,9 @@ def sgn_density_at_position(
         "area_µm²": area,
         "density_µm⁻²": density,
         "axis": axis,
+        "bb_min": bb_min,
+        "bb_max": bb_max,
+        "bb_center": bb_center,
     }
 
 
@@ -165,3 +188,46 @@ def _bbox_area(coords_2d: np.ndarray) -> float:
         return 0.0
     ranges = coords_2d.max(axis=0) - coords_2d.min(axis=0)
     return float(ranges[0] * ranges[1])
+
+
+def sgn_density_profile(
+    table: pd.DataFrame,
+    positions: Optional[List[Union[float, str]]] = None,
+    slice_thickness: float = 40.0,
+    run_length_tolerance: float = 0.1,
+    component_label: int = 1,
+    axis: str = "z",
+    length_fraction_column: str = "length_fraction",
+) -> dict:
+    """Compute SGN density at multiple cochlear positions.
+
+    Args:
+        table: SGN segmentation table (see sgn_density_at_position for required columns).
+        positions: List of positions to evaluate. Each entry is either a preset string
+                   ('apex', 'mid', 'base') or a float in [0, 1]. Default: ['apex', 'mid', 'base'].
+        slice_thickness: Total slice thickness in µm (default 40 µm).
+        run_length_tolerance: Max abs difference in length_fraction for inclusion (default 0.1).
+        component_label: Component label of the main RC component (default 1).
+        axis: Volume axis perpendicular to the slice plane (default 'z').
+        length_fraction_column: Column name for the run-length fraction (default 'length_fraction').
+
+    Returns:
+        dict keyed by position label (preset name or string-formatted float), each value
+        being the result dict from sgn_density_at_position.
+    """
+    if positions is None:
+        positions = ["apex", "mid", "base"]
+
+    results = {}
+    for pos in positions:
+        key = pos if isinstance(pos, str) else str(pos)
+        results[key] = sgn_density_at_position(
+            table,
+            reference_position=pos,
+            slice_thickness=slice_thickness,
+            run_length_tolerance=run_length_tolerance,
+            component_label=component_label,
+            axis=axis,
+            length_fraction_column=length_fraction_column,
+        )
+    return results

--- a/flamingo_tools/postprocessing/cli.py
+++ b/flamingo_tools/postprocessing/cli.py
@@ -340,3 +340,68 @@ def tonotopic_mapping():
         s3_bucket_name=args.s3_bucket_name,
         s3_service_endpoint=args.s3_service_endpoint,
     )
+
+
+def sgn_density():
+    parser = argparse.ArgumentParser(
+        description="Compute SGN density at one or more positions along the Rosenthal's Canal."
+    )
+
+    parser.add_argument("-i", "--input", type=str, required=True,
+                        help="Input path to SGN segmentation table (TSV). Must contain length_fraction column "
+                        "(produced by flamingo_tools.tonotopic_mapping).")
+    parser.add_argument("-o", "--output", type=str, required=True,
+                        help="Output path for JSON file with density results.")
+    parser.add_argument("-f", "--force", action="store_true", help="Forcefully overwrite output.")
+    parser.add_argument(
+        "-p", "--positions", type=str, nargs="+", default=["apex", "mid", "base"],
+        help="Cochlear positions to evaluate. Use preset names ('apex', 'mid', 'base') or "
+        "floats in [0, 1]. Default: apex mid base",
+    )
+    parser.add_argument(
+        "--slice_thickness", type=float, default=40.0,
+        help="Total thickness of the horizontal slice in µm. Default: 40.0",
+    )
+    parser.add_argument(
+        "--run_length_tolerance", type=float, default=0.1,
+        help="Maximum allowed length_fraction difference to include an SGN instance. "
+        "Reduces contamination from other cochlear turns. Default: 0.1",
+    )
+    parser.add_argument(
+        "-c", "--component_label", type=int, default=1,
+        help="Component label of the main Rosenthal's Canal component. Default: 1",
+    )
+    parser.add_argument(
+        "--axis", type=str, default="z", choices=["x", "y", "z"],
+        help="Volume axis perpendicular to the slice plane. Default: z",
+    )
+    parser.add_argument(
+        "--length_fraction_column", type=str, default="length_fraction",
+        help="Column name for the run-length fraction in the table. Default: length_fraction",
+    )
+
+    args = parser.parse_args()
+
+    import pandas as pd
+    from flamingo_tools.analysis.density_utils import sgn_density_profile
+
+    # Convert numeric position strings to floats.
+    positions = []
+    for p in args.positions:
+        try:
+            positions.append(float(p))
+        except ValueError:
+            positions.append(p)
+
+    table = pd.read_csv(args.input, sep="\t")
+    results = sgn_density_profile(
+        table,
+        positions=positions,
+        slice_thickness=args.slice_thickness,
+        run_length_tolerance=args.run_length_tolerance,
+        component_label=args.component_label,
+        axis=args.axis,
+        length_fraction_column=args.length_fraction_column,
+    )
+
+    export_dictionary_as_json(results, args.output, force_overwrite=args.force)

--- a/flamingo_tools/postprocessing/cli.py
+++ b/flamingo_tools/postprocessing/cli.py
@@ -410,6 +410,30 @@ def sgn_density():
         help="Local MoBIE project directory used to locate the table when --json_input is given "
         "and --input is absent.",
     )
+    parser.add_argument(
+        "--seg_path", type=str, default=None,
+        help="Path to the SGN segmentation volume (local TIF, N5/Zarr, or S3 OME-ZARR). "
+        "When omitted and --json_input is given, the path is derived automatically as "
+        "<dataset_name>/images/ome-zarr/<segmentation_channel>.ome.zarr. "
+        "Only used when --min_overlap_fraction is set.",
+    )
+    parser.add_argument(
+        "--seg_key", type=str, default="s0",
+        help="Internal key for N5/Zarr/OME-ZARR segmentation (default: s0).",
+    )
+    parser.add_argument(
+        "--min_overlap_fraction", type=float, default=None,
+        help="Minimum fraction of an SGN's voxels (n_pixels) that must lie within the "
+        "slice sub-volume to count the instance. Range (0, 1]. "
+        "Default: None (no segmentation-based filtering).",
+    )
+    parser.add_argument(
+        "--seg_offset", type=float, nargs=3, default=[0.0, 0.0, 0.0],
+        metavar=("X", "Y", "Z"),
+        help="Physical coordinates in µm of pixel (0,0,0) in the segmentation file "
+        "(x y z order). Use when --seg_path is a pre-extracted crop file. "
+        "Default: 0.0 0.0 0.0 (correct for a full OME-ZARR volume).",
+    )
 
     # options for S3 bucket
     parser.add_argument("--s3", action="store_true", help="Flag for using S3 bucket.")
@@ -428,6 +452,7 @@ def sgn_density():
 
     import pandas as pd
     from flamingo_tools.analysis.density_utils import sgn_density_profile, _build_block_extraction_dict
+    from flamingo_tools.file_utils import read_image_data
 
     # Resolve table path and optional JSON metadata.
     json_params = None
@@ -468,6 +493,36 @@ def sgn_density():
             table = pd.read_csv(f, sep="\t")
     else:
         table = pd.read_csv(table_path, sep="\t")
+
+    # Resolve voxel size.
+    voxel_size = args.voxel_size
+    if len(voxel_size) == 1:
+        voxel_size = voxel_size * 3
+    voxel_size = tuple(voxel_size)
+
+    # Resolve and load segmentation if overlap filtering is requested.
+    segmentation = None
+    if args.min_overlap_fraction is not None:
+        seg_path = args.seg_path
+        if seg_path is None and json_params is not None:
+            dataset_name = json_params["dataset_name"]
+            seg_channel = json_params.get("segmentation_channel", "SGN_v2")
+            if args.s3:
+                seg_path = f"{dataset_name}/images/ome-zarr/{seg_channel}.ome.zarr"
+            else:
+                seg_path = os.path.join(
+                    args.mobie_dir, dataset_name, "images", "ome-zarr",
+                    f"{seg_channel}.ome.zarr",
+                )
+        if seg_path is not None:
+            segmentation = read_image_data(
+                seg_path, args.seg_key,
+                from_s3=args.s3,
+                credential_file=args.s3_credentials,
+                bucket_name=args.s3_bucket_name,
+                service_endpoint=args.s3_service_endpoint,
+            )
+
     results = sgn_density_profile(
         table,
         positions=positions,
@@ -477,18 +532,19 @@ def sgn_density():
         axis=args.axis,
         length_fraction_column=args.length_fraction_column,
         mode=args.mode,
+        segmentation=segmentation,
+        voxel_size=voxel_size,
+        min_overlap_fraction=args.min_overlap_fraction,
+        seg_offset=tuple(args.seg_offset),
     )
 
     export_dictionary_as_json(results, args.output, force_overwrite=args.force)
 
     if args.json_output is not None:
-        voxel_size = args.voxel_size
-        if len(voxel_size) == 1:
-            voxel_size = voxel_size * 3
         block_list = _build_block_extraction_dict(
             results,
             input_json_params=json_params,
             roi_halo=args.roi_halo,
-            voxel_size=tuple(voxel_size),
+            voxel_size=voxel_size,
         )
         export_dictionary_as_json(block_list, args.json_output, force_overwrite=args.force)

--- a/flamingo_tools/postprocessing/cli.py
+++ b/flamingo_tools/postprocessing/cli.py
@@ -7,7 +7,8 @@ from .cochlea_mapping import tonotopic_mapping_json_wrapper, equidistant_centers
 from flamingo_tools.json_util import export_dictionary_as_json
 from flamingo_tools.measurements import object_measures_json_wrapper
 from flamingo_tools.extract_block_util import extract_block_json_wrapper, extract_central_block_from_json
-from flamingo_tools.s3_utils import MOBIE_FOLDER, get_s3_path
+from flamingo_tools.s3_utils import MOBIE_FOLDER
+from flamingo_tools.analysis.density_utils import calc_sgn_density
 
 
 def equidistant_centers():
@@ -377,8 +378,8 @@ def sgn_density():
         "Reduces contamination from other cochlear turns. Default: 0.1",
     )
     parser.add_argument(
-        "-c", "--component_label", type=int, default=1,
-        help="Component label of the main Rosenthal's Canal component. Default: 1",
+        "-c", "--component_label", type=int, nargs="+", default=[1],
+        help="Component label(s) of the main Rosenthal's Canal component. Default: 1",
     )
     parser.add_argument(
         "--axis", type=str, default="z", choices=["x", "y", "z"],
@@ -425,14 +426,8 @@ def sgn_density():
         "--min_overlap_fraction", type=float, default=None,
         help="Minimum fraction of an SGN's voxels (n_pixels) that must lie within the "
         "slice sub-volume to count the instance. Range (0, 1]. "
-        "Default: None (no segmentation-based filtering).",
-    )
-    parser.add_argument(
-        "--seg_offset", type=float, nargs=3, default=[0.0, 0.0, 0.0],
-        metavar=("X", "Y", "Z"),
-        help="Physical coordinates in µm of pixel (0,0,0) in the segmentation file "
-        "(x y z order). Use when --seg_path is a pre-extracted crop file. "
-        "Default: 0.0 0.0 0.0 (correct for a full OME-ZARR volume).",
+        "Default: None (no segmentation-based filtering). "
+        "Whether --seg_path is a pre-extracted crop or a full volume is detected automatically.",
     )
 
     # options for S3 bucket
@@ -447,104 +442,30 @@ def sgn_density():
 
     args = parser.parse_args()
 
-    import json
-    import os
-
-    import pandas as pd
-    from flamingo_tools.analysis.density_utils import sgn_density_profile, _build_block_extraction_dict
-    from flamingo_tools.file_utils import read_image_data
-
-    # Resolve table path and optional JSON metadata.
-    json_params = None
-    if args.json_input is not None:
-        with open(args.json_input) as f:
-            json_params = json.load(f)
-        if isinstance(json_params, list):
-            json_params = json_params[0]
-
-    if args.input is not None:
-        table_path = args.input
-    elif json_params is not None:
-        dataset_name = json_params["dataset_name"]
-        seg_channel = json_params.get("segmentation_channel", "SGN_v2")
-        if args.s3:
-            table_path = f"{dataset_name}/tables/{seg_channel}/default.tsv"
-        else:
-            table_path = os.path.join(args.mobie_dir, dataset_name, "tables", seg_channel, "default.tsv")
-    else:
+    if args.input is None and args.json_input is None:
         parser.error("Provide --input or --json_input.")
 
-    # Convert numeric position strings to floats.
-    positions = []
-    for p in args.positions:
-        try:
-            positions.append(float(p))
-        except ValueError:
-            positions.append(p)
-
-    if args.s3:
-        tsv_path, fs = get_s3_path(
-            table_path,
-            credential_file=args.s3_credentials,
-            bucket_name=args.s3_bucket_name,
-            service_endpoint=args.s3_service_endpoint,
-        )
-        with fs.open(tsv_path, "r") as f:
-            table = pd.read_csv(f, sep="\t")
-    else:
-        table = pd.read_csv(table_path, sep="\t")
-
-    # Resolve voxel size.
-    voxel_size = args.voxel_size
-    if len(voxel_size) == 1:
-        voxel_size = voxel_size * 3
-    voxel_size = tuple(voxel_size)
-
-    # Resolve and load segmentation if overlap filtering is requested.
-    segmentation = None
-    if args.min_overlap_fraction is not None:
-        seg_path = args.seg_path
-        if seg_path is None and json_params is not None:
-            dataset_name = json_params["dataset_name"]
-            seg_channel = json_params.get("segmentation_channel", "SGN_v2")
-            if args.s3:
-                seg_path = f"{dataset_name}/images/ome-zarr/{seg_channel}.ome.zarr"
-            else:
-                seg_path = os.path.join(
-                    args.mobie_dir, dataset_name, "images", "ome-zarr",
-                    f"{seg_channel}.ome.zarr",
-                )
-        if seg_path is not None:
-            segmentation = read_image_data(
-                seg_path, args.seg_key,
-                from_s3=args.s3,
-                credential_file=args.s3_credentials,
-                bucket_name=args.s3_bucket_name,
-                service_endpoint=args.s3_service_endpoint,
-            )
-
-    results = sgn_density_profile(
-        table,
-        positions=positions,
+    calc_sgn_density(
+        output=args.output,
+        seg_table_path=args.input,
+        json_input=args.json_input,
+        json_output=args.json_output,
+        force_overwrite=args.force,
+        positions=args.positions,
         slice_thickness=args.slice_thickness,
         run_length_tolerance=args.run_length_tolerance,
-        component_label=args.component_label,
+        component_list=args.component_label,
         axis=args.axis,
         length_fraction_column=args.length_fraction_column,
-        mode=args.mode,
-        segmentation=segmentation,
-        voxel_size=voxel_size,
+        density_mode=args.mode,
+        roi_halo=args.roi_halo,
+        voxel_size=args.voxel_size,
+        mobie_dir=args.mobie_dir,
+        seg_path=args.seg_path,
+        seg_key=args.seg_key,
         min_overlap_fraction=args.min_overlap_fraction,
-        seg_offset=tuple(args.seg_offset),
+        s3=args.s3,
+        s3_credentials=args.s3_credentials,
+        s3_bucket_name=args.s3_bucket_name,
+        s3_service_endpoint=args.s3_service_endpoint,
     )
-
-    export_dictionary_as_json(results, args.output, force_overwrite=args.force)
-
-    if args.json_output is not None:
-        block_list = _build_block_extraction_dict(
-            results,
-            input_json_params=json_params,
-            roi_halo=args.roi_halo,
-            voxel_size=voxel_size,
-        )
-        export_dictionary_as_json(block_list, args.json_output, force_overwrite=args.force)

--- a/flamingo_tools/postprocessing/cli.py
+++ b/flamingo_tools/postprocessing/cli.py
@@ -7,7 +7,7 @@ from .cochlea_mapping import tonotopic_mapping_json_wrapper, equidistant_centers
 from flamingo_tools.json_util import export_dictionary_as_json
 from flamingo_tools.measurements import object_measures_json_wrapper
 from flamingo_tools.extract_block_util import extract_block_json_wrapper, extract_central_block_from_json
-from flamingo_tools.s3_utils import MOBIE_FOLDER
+from flamingo_tools.s3_utils import MOBIE_FOLDER, get_s3_path
 
 
 def equidistant_centers():
@@ -411,6 +411,16 @@ def sgn_density():
         "and --input is absent.",
     )
 
+    # options for S3 bucket
+    parser.add_argument("--s3", action="store_true", help="Flag for using S3 bucket.")
+    parser.add_argument("--s3_credentials", type=str, default=None,
+                        help="Input file containing S3 credentials. "
+                        "Optional if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY were exported.")
+    parser.add_argument("--s3_bucket_name", type=str, default=None,
+                        help="S3 bucket name. Optional if BUCKET_NAME was exported.")
+    parser.add_argument("--s3_service_endpoint", type=str, default=None,
+                        help="S3 service endpoint. Optional if SERVICE_ENDPOINT was exported.")
+
     args = parser.parse_args()
 
     import json
@@ -432,7 +442,10 @@ def sgn_density():
     elif json_params is not None:
         dataset_name = json_params["dataset_name"]
         seg_channel = json_params.get("segmentation_channel", "SGN_v2")
-        table_path = os.path.join(args.mobie_dir, dataset_name, "tables", seg_channel, "default.tsv")
+        if args.s3:
+            table_path = f"{dataset_name}/tables/{seg_channel}/default.tsv"
+        else:
+            table_path = os.path.join(args.mobie_dir, dataset_name, "tables", seg_channel, "default.tsv")
     else:
         parser.error("Provide --input or --json_input.")
 
@@ -444,7 +457,17 @@ def sgn_density():
         except ValueError:
             positions.append(p)
 
-    table = pd.read_csv(table_path, sep="\t")
+    if args.s3:
+        tsv_path, fs = get_s3_path(
+            table_path,
+            credential_file=args.s3_credentials,
+            bucket_name=args.s3_bucket_name,
+            service_endpoint=args.s3_service_endpoint,
+        )
+        with fs.open(tsv_path, "r") as f:
+            table = pd.read_csv(f, sep="\t")
+    else:
+        table = pd.read_csv(table_path, sep="\t")
     results = sgn_density_profile(
         table,
         positions=positions,

--- a/flamingo_tools/postprocessing/cli.py
+++ b/flamingo_tools/postprocessing/cli.py
@@ -347,11 +347,20 @@ def sgn_density():
         description="Compute SGN density at one or more positions along the Rosenthal's Canal."
     )
 
-    parser.add_argument("-i", "--input", type=str, required=True,
+    parser.add_argument("-i", "--input", type=str, default=None,
                         help="Input path to SGN segmentation table (TSV). Must contain length_fraction column "
-                        "(produced by flamingo_tools.tonotopic_mapping).")
+                        "(produced by flamingo_tools.tonotopic_mapping). "
+                        "Optional when --json_input is supplied.")
+    parser.add_argument("-j", "--json_input", type=str, default=None,
+                        help="Input JSON file with metadata information(dataset_name, image_channel, "
+                        "segmentation_channel, …). When --input is absent the table path "
+                        "is derived from dataset_name and segmentation_channel via --mobie_dir.")
     parser.add_argument("-o", "--output", type=str, required=True,
                         help="Output path for JSON file with density results.")
+    parser.add_argument("--json_output", type=str, default=None,
+                        help="Optional output path for block-extraction JSON compatible with "
+                        "flamingo_tools.extract_block --json_info. "
+                        "Contains crop_centers derived from the density bounding boxes.")
     parser.add_argument("-f", "--force", action="store_true", help="Forcefully overwrite output.")
     parser.add_argument(
         "-p", "--positions", type=str, nargs="+", default=["apex", "mid", "base"],
@@ -359,8 +368,8 @@ def sgn_density():
         "floats in [0, 1]. Default: apex mid base",
     )
     parser.add_argument(
-        "--slice_thickness", type=float, default=40.0,
-        help="Total thickness of the horizontal slice in µm. Default: 40.0",
+        "--slice_thickness", type=float, default=10.0,
+        help="Total thickness of the horizontal slice in µm. Default: 10.0",
     )
     parser.add_argument(
         "--run_length_tolerance", type=float, default=0.1,
@@ -379,11 +388,53 @@ def sgn_density():
         "--length_fraction_column", type=str, default="length_fraction",
         help="Column name for the run-length fraction in the table. Default: length_fraction",
     )
+    parser.add_argument(
+        "--mode", type=str, default="2d", choices=["2d", "3d"],
+        help="Density mode: '2d' computes density per cross-sectional area (SGN/µm²); "
+        "'3d' computes density per convex-hull volume (SGN/µm³). Default: 2d",
+    )
+    parser.add_argument(
+        "--roi_halo", type=int, nargs=3, default=None, metavar=("X", "Y", "Z"),
+        help="ROI halo in pixels [x y z] for the block-extraction JSON output, applied to all "
+        "positions. Overrides the value from --json_input. "
+        "If omitted, the halo is computed automatically from each position's bounding box.",
+    )
+    parser.add_argument(
+        "--voxel_size", type=float, nargs="+", default=[0.38, 0.38, 0.38],
+        help="Voxel size in µm used to convert bounding box extents to pixels when "
+        "computing the automatic roi_halo. Provide 1 value (isotropic) or 3 values (x y z). "
+        "Default: 0.38 0.38 0.38",
+    )
+    parser.add_argument(
+        "--mobie_dir", type=str, default=MOBIE_FOLDER,
+        help="Local MoBIE project directory used to locate the table when --json_input is given "
+        "and --input is absent.",
+    )
 
     args = parser.parse_args()
 
+    import json
+    import os
+
     import pandas as pd
-    from flamingo_tools.analysis.density_utils import sgn_density_profile
+    from flamingo_tools.analysis.density_utils import sgn_density_profile, _build_block_extraction_dict
+
+    # Resolve table path and optional JSON metadata.
+    json_params = None
+    if args.json_input is not None:
+        with open(args.json_input) as f:
+            json_params = json.load(f)
+        if isinstance(json_params, list):
+            json_params = json_params[0]
+
+    if args.input is not None:
+        table_path = args.input
+    elif json_params is not None:
+        dataset_name = json_params["dataset_name"]
+        seg_channel = json_params.get("segmentation_channel", "SGN_v2")
+        table_path = os.path.join(args.mobie_dir, dataset_name, "tables", seg_channel, "default.tsv")
+    else:
+        parser.error("Provide --input or --json_input.")
 
     # Convert numeric position strings to floats.
     positions = []
@@ -393,7 +444,7 @@ def sgn_density():
         except ValueError:
             positions.append(p)
 
-    table = pd.read_csv(args.input, sep="\t")
+    table = pd.read_csv(table_path, sep="\t")
     results = sgn_density_profile(
         table,
         positions=positions,
@@ -402,6 +453,19 @@ def sgn_density():
         component_label=args.component_label,
         axis=args.axis,
         length_fraction_column=args.length_fraction_column,
+        mode=args.mode,
     )
 
     export_dictionary_as_json(results, args.output, force_overwrite=args.force)
+
+    if args.json_output is not None:
+        voxel_size = args.voxel_size
+        if len(voxel_size) == 1:
+            voxel_size = voxel_size * 3
+        block_list = _build_block_extraction_dict(
+            results,
+            input_json_params=json_params,
+            roi_halo=args.roi_halo,
+            voxel_size=tuple(voxel_size),
+        )
+        export_dictionary_as_json(block_list, args.json_output, force_overwrite=args.force)

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
             "flamingo_tools.label_components = flamingo_tools.postprocessing.cli:label_components",
             "flamingo_tools.object_measures = flamingo_tools.postprocessing.cli:object_measures",
             "flamingo_tools.tonotopic_mapping = flamingo_tools.postprocessing.cli:tonotopic_mapping",
+            "flamingo_tools.sgn_density = flamingo_tools.postprocessing.cli:sgn_density",
             # TODO: MoBIE conversion
         ],
         "napari.manifest": [

--- a/test/test_density_utils.py
+++ b/test/test_density_utils.py
@@ -78,7 +78,7 @@ class TestSgnDensityAtPosition(unittest.TestCase):
         extra = _make_table(n=20, frac_center=0.5, component_label=2)
         extra["label_id"] += 100
         combined = pd.concat([self.table, extra], ignore_index=True)
-        result = self.fn(combined, reference_position="mid", component_label=1)
+        result = self.fn(combined, reference_position="mid", component_list=[1])
         self.assertEqual(result["n_sgns"], 20)
 
     def test_invalid_axis(self):
@@ -304,13 +304,17 @@ class TestBuildBlockExtractionDict(unittest.TestCase):
             self.assertNotIn("dataset_name", entry)
 
 
-def _make_seg_array(table, shape_zyx, voxel_size=(1.0, 1.0, 1.0), offset=(0.0, 0.0, 0.0)):
-    """Paint one voxel per label_id at its anchor position into a (Z, Y, X) array."""
+def _make_seg_array(table, shape_zyx, voxel_size=(1.0, 1.0, 1.0), origin_xyz=(0.0, 0.0, 0.0)):
+    """Paint one voxel per label_id at its anchor position into a (Z, Y, X) array.
+
+    `origin_xyz` is the physical coordinate of pixel (0,0,0) of the array (µm, x/y/z order).
+    For a full volume use (0,0,0); for a crop set to the crop's lower-left corner.
+    """
     seg = np.zeros(shape_zyx, dtype=np.int32)
     for _, row in table.iterrows():
-        z = round((row["anchor_z"] - offset[2]) / voxel_size[2])
-        y = round((row["anchor_y"] - offset[1]) / voxel_size[1])
-        x = round((row["anchor_x"] - offset[0]) / voxel_size[0])
+        z = round((row["anchor_z"] - origin_xyz[2]) / voxel_size[2])
+        y = round((row["anchor_y"] - origin_xyz[1]) / voxel_size[1])
+        x = round((row["anchor_x"] - origin_xyz[0]) / voxel_size[0])
         if 0 <= z < shape_zyx[0] and 0 <= y < shape_zyx[1] and 0 <= x < shape_zyx[2]:
             seg[z, y, x] = int(row["label_id"])
     return seg
@@ -391,6 +395,22 @@ class TestFilterBySegmentationOverlap(unittest.TestCase):
         result = self.fn(self.table, reference_position="mid")
         self.assertIn("min_overlap_fraction", result)
         self.assertIsNone(result["min_overlap_fraction"])
+
+    def test_crop_auto_detection(self):
+        # Build a small crop array whose z-extent (40 µm) is less than the max anchor
+        # coordinate (~53 µm), triggering the crop-detection path.  Labels are painted
+        # relative to the crop origin at z=30 µm, so all anchors (z≈47-53) map to
+        # pixels z≈17-23 inside the 40-px array.
+        crop_origin_z = 30.0
+        crop_shape_zyx = (40, 100, 80)
+        seg = _make_seg_array(
+            self.table, crop_shape_zyx, self.voxel_size, origin_xyz=(0.0, 0.0, crop_origin_z)
+        )
+        result = self.fn(
+            self.table, reference_position="mid", slice_thickness=40.0,
+            segmentation=seg, voxel_size=self.voxel_size, min_overlap_fraction=1 / 500,
+        )
+        self.assertEqual(result["n_sgns"], 20)
 
 
 if __name__ == "__main__":

--- a/test/test_density_utils.py
+++ b/test/test_density_utils.py
@@ -42,8 +42,8 @@ class TestSgnDensityAtPosition(unittest.TestCase):
     def test_basic_mid(self):
         result = self.fn(self.table, reference_position="mid", slice_thickness=40.0)
         self.assertEqual(result["n_sgns"], 20)
-        self.assertGreater(result["area_µm²"], 0.0)
-        self.assertAlmostEqual(result["density_µm⁻²"], result["n_sgns"] / result["area_µm²"])
+        self.assertGreater(result["area"], 0.0)
+        self.assertAlmostEqual(result["density"], result["n_sgns"] / result["area"])
         self.assertEqual(result["axis"], "z")
 
     def test_preset_fractions(self):
@@ -58,17 +58,13 @@ class TestSgnDensityAtPosition(unittest.TestCase):
         self.assertEqual(result["reference_fraction"], 0.5)
 
     def test_run_length_filtering(self):
-        # Add 5 extra instances far from frac=0.5 that still overlap the z-slice.
         extra = _make_table(n=20, z_center=50.0, frac_center=0.8, frac_spread=0.01)
         extra["label_id"] += 100
         combined = pd.concat([self.table, extra], ignore_index=True)
-
-        # With tight tolerance, extras should be excluded.
         result = self.fn(combined, reference_position="mid", slice_thickness=40.0, run_length_tolerance=0.1)
         self.assertEqual(result["n_sgns"], 20)
 
     def test_slice_thickness_limits(self):
-        # With zero thickness, only instances whose bb straddles the center survive.
         result_thin = self.fn(self.table, reference_position="mid", slice_thickness=1.0)
         result_thick = self.fn(self.table, reference_position="mid", slice_thickness=40.0)
         self.assertLessEqual(result_thin["n_sgns"], result_thick["n_sgns"])
@@ -79,7 +75,6 @@ class TestSgnDensityAtPosition(unittest.TestCase):
             self.assertEqual(result["axis"], ax)
 
     def test_component_filter(self):
-        # Component label 2 instances are outside the default filter.
         extra = _make_table(n=20, frac_center=0.5, component_label=2)
         extra["label_id"] += 100
         combined = pd.concat([self.table, extra], ignore_index=True)
@@ -98,32 +93,60 @@ class TestSgnDensityAtPosition(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.fn(self.table, reference_position=1.5)
 
+    def test_invalid_mode(self):
+        with self.assertRaises(ValueError):
+            self.fn(self.table, mode="flat")
+
     def test_missing_column(self):
         bad = self.table.drop(columns=["length_fraction"])
         with self.assertRaises(ValueError):
             self.fn(bad)
 
-    def test_result_keys(self):
-        result = self.fn(self.table)
-        expected_keys = {
+    def test_result_keys_2d(self):
+        result = self.fn(self.table, mode="2d")
+        expected = {
             "reference_fraction", "reference_label_id", "slice_center",
-            "slice_min", "slice_max", "n_sgns", "area_µm²", "density_µm⁻²", "axis",
+            "slice_min", "slice_max", "slice_thickness", "n_sgns",
+            "area", "density", "mode", "axis",
             "bb_min", "bb_max", "bb_center",
         }
-        self.assertEqual(set(result.keys()), expected_keys)
+        self.assertEqual(set(result.keys()), expected)
+        self.assertNotIn("volume", result)
+
+    def test_result_keys_3d(self):
+        result = self.fn(self.table, mode="3d")
+        expected = {
+            "reference_fraction", "reference_label_id", "slice_center",
+            "slice_min", "slice_max", "slice_thickness", "n_sgns",
+            "volume", "density", "mode", "axis",
+            "bb_min", "bb_max", "bb_center",
+        }
+        self.assertEqual(set(result.keys()), expected)
+        self.assertNotIn("area", result)
+
+    def test_3d_mode(self):
+        result = self.fn(self.table, mode="3d", slice_thickness=40.0)
+        self.assertEqual(result["mode"], "3d")
+        self.assertIn("volume", result)
+        self.assertGreater(result["volume"], 0.0)
+        self.assertAlmostEqual(result["density"], result["n_sgns"] / result["volume"])
+
+    def test_3d_mode_larger_extent_than_2d(self):
+        r2d = self.fn(self.table, mode="2d", slice_thickness=40.0)
+        r3d = self.fn(self.table, mode="3d", slice_thickness=40.0)
+        # Same SGNs selected; 3D volume > 2D area for a non-flat cluster
+        self.assertEqual(r2d["n_sgns"], r3d["n_sgns"])
 
     def test_bounding_box_shape(self):
         result = self.fn(self.table, reference_position="mid", slice_thickness=40.0)
         for key in ("bb_min", "bb_max", "bb_center"):
             self.assertEqual(len(result[key]), 3, f"{key} should have 3 components")
-        # bb_min <= bb_center <= bb_max for each axis
         for lo, center, hi in zip(result["bb_min"], result["bb_center"], result["bb_max"]):
             self.assertLessEqual(lo, center)
             self.assertLessEqual(center, hi)
 
     def test_bounding_box_covers_slice_axis(self):
         result = self.fn(self.table, reference_position="mid", slice_thickness=40.0, axis="z")
-        # The z range of the bounding box must contain the slice window.
         self.assertLessEqual(result["bb_min"][2], result["slice_max"])
         self.assertGreaterEqual(result["bb_max"][2], result["slice_min"])
 
@@ -136,8 +159,6 @@ class TestSgnDensityProfile(unittest.TestCase):
         self.table = _make_table()
 
     def test_default_positions(self):
-        # Default produces three preset positions, but mid table only has mid data —
-        # use a table spanning all three preset fractions so each finds a closest match.
         fracs = [0.15, 0.5, 0.85]
         rows = [_make_table(n=20, frac_center=f, frac_spread=0.02) for f in fracs]
         for i, t in enumerate(rows[1:], 1):
@@ -146,7 +167,7 @@ class TestSgnDensityProfile(unittest.TestCase):
         results = self.fn(combined, run_length_tolerance=0.05)
         self.assertEqual(set(results.keys()), {"apex", "mid", "base"})
         for key in results:
-            self.assertIn("density_µm⁻²", results[key])
+            self.assertIn("density", results[key])
 
     def test_custom_positions(self):
         results = self.fn(self.table, positions=["mid", 0.5])
@@ -157,6 +178,113 @@ class TestSgnDensityProfile(unittest.TestCase):
         results = self.fn(self.table, positions=[0.3])
         self.assertIn("0.3", results)
         self.assertEqual(results["0.3"]["reference_fraction"], 0.3)
+
+    def test_mode_forwarded(self):
+        results = self.fn(self.table, positions=["mid"], mode="3d")
+        self.assertEqual(results["mid"]["mode"], "3d")
+        self.assertIn("volume", results["mid"])
+
+
+class TestBuildBlockExtractionDict(unittest.TestCase):
+
+    def setUp(self):
+        from flamingo_tools.analysis.density_utils import sgn_density_profile, _build_block_extraction_dict
+        self.build = _build_block_extraction_dict
+        fracs = [0.15, 0.5, 0.85]
+        rows = [_make_table(n=20, frac_center=f, frac_spread=0.02) for f in fracs]
+        for i, t in enumerate(rows[1:], 1):
+            t["label_id"] += i * 100
+        combined = pd.concat(rows, ignore_index=True)
+        self.density_results = sgn_density_profile(
+            combined, run_length_tolerance=0.05, slice_thickness=40.0
+        )
+
+    def test_returns_list(self):
+        out = self.build(self.density_results)
+        self.assertIsInstance(out, list)
+
+    def test_one_entry_per_position(self):
+        out = self.build(self.density_results)
+        self.assertEqual(len(out), len(self.density_results))
+
+    def test_each_entry_has_single_crop_center(self):
+        out = self.build(self.density_results)
+        for entry in out:
+            self.assertIn("crop_centers", entry)
+            self.assertEqual(len(entry["crop_centers"]), 1)
+
+    def test_crop_centers_are_int_triples(self):
+        out = self.build(self.density_results)
+        for entry in out:
+            center = entry["crop_centers"][0]
+            self.assertEqual(len(center), 3)
+            for v in center:
+                self.assertIsInstance(v, int)
+
+    def test_position_labels_match_keys(self):
+        out = self.build(self.density_results)
+        labels = [entry["position_label"] for entry in out]
+        self.assertEqual(labels, list(self.density_results.keys()))
+
+    def test_auto_roi_halo_default(self):
+        # No explicit halo and no input JSON → auto-computed from bounding box.
+        out = self.build(self.density_results)
+        for entry in out:
+            halo = entry["roi_halo"]
+            self.assertEqual(len(halo), 3)
+            for v in halo:
+                self.assertIsInstance(v, int)
+                self.assertGreater(v, 0)
+
+    def test_auto_roi_halo_covers_bbox(self):
+        # Auto halo must be >= half the bounding box extent in each axis.
+        import math
+        voxel_size = (0.38, 0.38, 0.38)
+        out = self.build(self.density_results, voxel_size=voxel_size)
+        for entry, (label, pos_result) in zip(out, self.density_results.items()):
+            bb_min = pos_result["bb_min"]
+            bb_max = pos_result["bb_max"]
+            for i, (lo, hi, vs) in enumerate(zip(bb_min, bb_max, voxel_size)):
+                min_required = math.ceil((hi - lo) / 2.0 / vs)
+                self.assertGreaterEqual(entry["roi_halo"][i], min_required)
+
+    def test_roi_halo_from_json_params(self):
+        params = {"dataset_name": "test", "roi_halo": [256, 256, 50]}
+        out = self.build(self.density_results, input_json_params=params)
+        for entry in out:
+            self.assertEqual(entry["roi_halo"], [256, 256, 50])
+
+    def test_roi_halo_explicit_overrides_json(self):
+        params = {"roi_halo": [256, 256, 50]}
+        out = self.build(self.density_results, input_json_params=params, roi_halo=[64, 64, 32])
+        for entry in out:
+            self.assertEqual(entry["roi_halo"], [64, 64, 32])
+
+    def test_per_position_halo_can_differ(self):
+        # With auto-halo and positions at different distances, halos may differ.
+        out = self.build(self.density_results)
+        halos = [tuple(entry["roi_halo"]) for entry in out]
+        # At least check we get 3 per-position entries (may or may not differ).
+        self.assertEqual(len(halos), 3)
+
+    def test_metadata_from_json_params(self):
+        params = {
+            "dataset_name": "M_LR_000155_L",
+            "image_channel": ["PV", "GFP", "SGN_v2"],
+            "segmentation_channel": "SGN_v2",
+            "cell_type": "sgn",
+            "component_list": [1],
+        }
+        out = self.build(self.density_results, input_json_params=params)
+        for entry in out:
+            self.assertEqual(entry["dataset_name"], "M_LR_000155_L")
+            self.assertEqual(entry["image_channel"], ["PV", "GFP", "SGN_v2"])
+            self.assertEqual(entry["segmentation_channel"], "SGN_v2")
+
+    def test_no_json_params(self):
+        out = self.build(self.density_results)
+        for entry in out:
+            self.assertNotIn("dataset_name", entry)
 
 
 if __name__ == "__main__":

--- a/test/test_density_utils.py
+++ b/test/test_density_utils.py
@@ -236,15 +236,32 @@ class TestBuildBlockExtractionDict(unittest.TestCase):
                 self.assertIsInstance(v, int)
                 self.assertGreater(v, 0)
 
-    def test_auto_roi_halo_covers_bbox(self):
-        # Auto halo must be >= half the bounding box extent in each axis.
+    def test_auto_roi_halo_slice_axis_matches_slice_thickness(self):
+        # Along the slice axis the halo must equal ceil(slice_thickness / 2 / voxel_size).
         import math
         voxel_size = (0.38, 0.38, 0.38)
+        axis_index = {"x": 0, "y": 1, "z": 2}
         out = self.build(self.density_results, voxel_size=voxel_size)
         for entry, (label, pos_result) in zip(out, self.density_results.items()):
+            ax = pos_result["axis"]
+            st = pos_result["slice_thickness"]
+            vs = voxel_size[axis_index[ax]]
+            expected = max(10, math.ceil(st / 2.0 / vs))
+            self.assertEqual(entry["roi_halo"][axis_index[ax]], expected)
+
+    def test_auto_roi_halo_projection_axes_cover_bbox(self):
+        # Along the two projection axes the halo must cover the bounding box half-extents.
+        import math
+        voxel_size = (0.38, 0.38, 0.38)
+        axis_index = {"x": 0, "y": 1, "z": 2}
+        out = self.build(self.density_results, voxel_size=voxel_size)
+        for entry, (label, pos_result) in zip(out, self.density_results.items()):
+            ax_i = axis_index[pos_result["axis"]]
             bb_min = pos_result["bb_min"]
             bb_max = pos_result["bb_max"]
             for i, (lo, hi, vs) in enumerate(zip(bb_min, bb_max, voxel_size)):
+                if i == ax_i:
+                    continue  # slice axis tested separately
                 min_required = math.ceil((hi - lo) / 2.0 / vs)
                 self.assertGreaterEqual(entry["roi_halo"][i], min_required)
 

--- a/test/test_density_utils.py
+++ b/test/test_density_utils.py
@@ -108,8 +108,55 @@ class TestSgnDensityAtPosition(unittest.TestCase):
         expected_keys = {
             "reference_fraction", "reference_label_id", "slice_center",
             "slice_min", "slice_max", "n_sgns", "area_µm²", "density_µm⁻²", "axis",
+            "bb_min", "bb_max", "bb_center",
         }
         self.assertEqual(set(result.keys()), expected_keys)
+
+    def test_bounding_box_shape(self):
+        result = self.fn(self.table, reference_position="mid", slice_thickness=40.0)
+        for key in ("bb_min", "bb_max", "bb_center"):
+            self.assertEqual(len(result[key]), 3, f"{key} should have 3 components")
+        # bb_min <= bb_center <= bb_max for each axis
+        for lo, center, hi in zip(result["bb_min"], result["bb_center"], result["bb_max"]):
+            self.assertLessEqual(lo, center)
+            self.assertLessEqual(center, hi)
+
+    def test_bounding_box_covers_slice_axis(self):
+        result = self.fn(self.table, reference_position="mid", slice_thickness=40.0, axis="z")
+        # The z range of the bounding box must contain the slice window.
+        self.assertLessEqual(result["bb_min"][2], result["slice_max"])
+        self.assertGreaterEqual(result["bb_max"][2], result["slice_min"])
+
+
+class TestSgnDensityProfile(unittest.TestCase):
+
+    def setUp(self):
+        from flamingo_tools.analysis.density_utils import sgn_density_profile
+        self.fn = sgn_density_profile
+        self.table = _make_table()
+
+    def test_default_positions(self):
+        # Default produces three preset positions, but mid table only has mid data —
+        # use a table spanning all three preset fractions so each finds a closest match.
+        fracs = [0.15, 0.5, 0.85]
+        rows = [_make_table(n=20, frac_center=f, frac_spread=0.02) for f in fracs]
+        for i, t in enumerate(rows[1:], 1):
+            t["label_id"] += i * 100
+        combined = pd.concat(rows, ignore_index=True)
+        results = self.fn(combined, run_length_tolerance=0.05)
+        self.assertEqual(set(results.keys()), {"apex", "mid", "base"})
+        for key in results:
+            self.assertIn("density_µm⁻²", results[key])
+
+    def test_custom_positions(self):
+        results = self.fn(self.table, positions=["mid", 0.5])
+        self.assertIn("mid", results)
+        self.assertIn("0.5", results)
+
+    def test_float_position_key_format(self):
+        results = self.fn(self.table, positions=[0.3])
+        self.assertIn("0.3", results)
+        self.assertEqual(results["0.3"]["reference_fraction"], 0.3)
 
 
 if __name__ == "__main__":

--- a/test/test_density_utils.py
+++ b/test/test_density_utils.py
@@ -1,0 +1,116 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+
+
+def _make_table(n=20, z_center=50.0, frac_center=0.5, frac_spread=0.05, component_label=1):
+    """Build a synthetic SGN table with n instances in a grid around z_center."""
+    rng = np.random.default_rng(42)
+    nx, ny = 4, 5
+    assert nx * ny == n
+
+    ax = np.tile(np.linspace(0.0, 60.0, nx), ny)
+    ay = np.repeat(np.linspace(0.0, 80.0, ny), nx)
+    az = np.full(n, z_center) + rng.uniform(-3.0, 3.0, n)
+    half = 5.0
+
+    return pd.DataFrame({
+        "label_id": np.arange(1, n + 1),
+        "anchor_x": ax,
+        "anchor_y": ay,
+        "anchor_z": az,
+        "bb_min_x": ax - half,
+        "bb_max_x": ax + half,
+        "bb_min_y": ay - half,
+        "bb_max_y": ay + half,
+        "bb_min_z": az - half,
+        "bb_max_z": az + half,
+        "n_pixels": np.full(n, 500),
+        "component_labels": np.full(n, component_label, dtype=int),
+        "length_fraction": np.linspace(frac_center - frac_spread, frac_center + frac_spread, n),
+    })
+
+
+class TestSgnDensityAtPosition(unittest.TestCase):
+
+    def setUp(self):
+        from flamingo_tools.analysis.density_utils import sgn_density_at_position
+        self.fn = sgn_density_at_position
+        self.table = _make_table()
+
+    def test_basic_mid(self):
+        result = self.fn(self.table, reference_position="mid", slice_thickness=40.0)
+        self.assertEqual(result["n_sgns"], 20)
+        self.assertGreater(result["area_µm²"], 0.0)
+        self.assertAlmostEqual(result["density_µm⁻²"], result["n_sgns"] / result["area_µm²"])
+        self.assertEqual(result["axis"], "z")
+
+    def test_preset_fractions(self):
+        from flamingo_tools.analysis.density_utils import REFERENCE_PRESETS
+        for name, val in REFERENCE_PRESETS.items():
+            t = _make_table(frac_center=val)
+            result = self.fn(t, reference_position=name, run_length_tolerance=0.1)
+            self.assertEqual(result["reference_fraction"], val)
+
+    def test_custom_float(self):
+        result = self.fn(self.table, reference_position=0.5)
+        self.assertEqual(result["reference_fraction"], 0.5)
+
+    def test_run_length_filtering(self):
+        # Add 5 extra instances far from frac=0.5 that still overlap the z-slice.
+        extra = _make_table(n=20, z_center=50.0, frac_center=0.8, frac_spread=0.01)
+        extra["label_id"] += 100
+        combined = pd.concat([self.table, extra], ignore_index=True)
+
+        # With tight tolerance, extras should be excluded.
+        result = self.fn(combined, reference_position="mid", slice_thickness=40.0, run_length_tolerance=0.1)
+        self.assertEqual(result["n_sgns"], 20)
+
+    def test_slice_thickness_limits(self):
+        # With zero thickness, only instances whose bb straddles the center survive.
+        result_thin = self.fn(self.table, reference_position="mid", slice_thickness=1.0)
+        result_thick = self.fn(self.table, reference_position="mid", slice_thickness=40.0)
+        self.assertLessEqual(result_thin["n_sgns"], result_thick["n_sgns"])
+
+    def test_configurable_axis(self):
+        for ax in ("x", "y", "z"):
+            result = self.fn(self.table, reference_position="mid", axis=ax)
+            self.assertEqual(result["axis"], ax)
+
+    def test_component_filter(self):
+        # Component label 2 instances are outside the default filter.
+        extra = _make_table(n=20, frac_center=0.5, component_label=2)
+        extra["label_id"] += 100
+        combined = pd.concat([self.table, extra], ignore_index=True)
+        result = self.fn(combined, reference_position="mid", component_label=1)
+        self.assertEqual(result["n_sgns"], 20)
+
+    def test_invalid_axis(self):
+        with self.assertRaises(ValueError):
+            self.fn(self.table, axis="w")
+
+    def test_invalid_preset(self):
+        with self.assertRaises(ValueError):
+            self.fn(self.table, reference_position="tip")
+
+    def test_out_of_range_float(self):
+        with self.assertRaises(ValueError):
+            self.fn(self.table, reference_position=1.5)
+
+    def test_missing_column(self):
+        bad = self.table.drop(columns=["length_fraction"])
+        with self.assertRaises(ValueError):
+            self.fn(bad)
+
+    def test_result_keys(self):
+        result = self.fn(self.table)
+        expected_keys = {
+            "reference_fraction", "reference_label_id", "slice_center",
+            "slice_min", "slice_max", "n_sgns", "area_µm²", "density_µm⁻²", "axis",
+        }
+        self.assertEqual(set(result.keys()), expected_keys)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_density_utils.py
+++ b/test/test_density_utils.py
@@ -108,7 +108,7 @@ class TestSgnDensityAtPosition(unittest.TestCase):
             "reference_fraction", "reference_label_id", "slice_center",
             "slice_min", "slice_max", "slice_thickness", "n_sgns",
             "area", "density", "mode", "axis",
-            "bb_min", "bb_max", "bb_center",
+            "bb_min", "bb_max", "bb_center", "min_overlap_fraction",
         }
         self.assertEqual(set(result.keys()), expected)
         self.assertNotIn("volume", result)
@@ -119,7 +119,7 @@ class TestSgnDensityAtPosition(unittest.TestCase):
             "reference_fraction", "reference_label_id", "slice_center",
             "slice_min", "slice_max", "slice_thickness", "n_sgns",
             "volume", "density", "mode", "axis",
-            "bb_min", "bb_max", "bb_center",
+            "bb_min", "bb_max", "bb_center", "min_overlap_fraction",
         }
         self.assertEqual(set(result.keys()), expected)
         self.assertNotIn("area", result)
@@ -302,6 +302,95 @@ class TestBuildBlockExtractionDict(unittest.TestCase):
         out = self.build(self.density_results)
         for entry in out:
             self.assertNotIn("dataset_name", entry)
+
+
+def _make_seg_array(table, shape_zyx, voxel_size=(1.0, 1.0, 1.0), offset=(0.0, 0.0, 0.0)):
+    """Paint one voxel per label_id at its anchor position into a (Z, Y, X) array."""
+    seg = np.zeros(shape_zyx, dtype=np.int32)
+    for _, row in table.iterrows():
+        z = round((row["anchor_z"] - offset[2]) / voxel_size[2])
+        y = round((row["anchor_y"] - offset[1]) / voxel_size[1])
+        x = round((row["anchor_x"] - offset[0]) / voxel_size[0])
+        if 0 <= z < shape_zyx[0] and 0 <= y < shape_zyx[1] and 0 <= x < shape_zyx[2]:
+            seg[z, y, x] = int(row["label_id"])
+    return seg
+
+
+class TestFilterBySegmentationOverlap(unittest.TestCase):
+
+    def setUp(self):
+        from flamingo_tools.analysis.density_utils import sgn_density_at_position
+        self.fn = sgn_density_at_position
+        # Use integer voxel size so physical coords = pixel coords (easy to reason about).
+        self.voxel_size = (1.0, 1.0, 1.0)
+        self.table = _make_table(n=20, z_center=50.0, frac_center=0.5, frac_spread=0.05)
+        # Shape covers the full coordinate range of _make_table (x≤65, y≤85, z~50±8).
+        self.shape_zyx = (120, 100, 80)
+
+    def _seg_in_slice(self):
+        """Segmentation array with all anchors visible in a z-slice around 50."""
+        return _make_seg_array(self.table, self.shape_zyx, self.voxel_size)
+
+    def _seg_out_of_slice(self):
+        """Segmentation array with all anchors shifted 60 µm above the slice."""
+        shifted = self.table.copy()
+        shifted["anchor_z"] += 60.0
+        shifted["bb_min_z"] += 60.0
+        shifted["bb_max_z"] += 60.0
+        return _make_seg_array(shifted, self.shape_zyx, self.voxel_size)
+
+    def test_all_kept_when_fully_in_slice(self):
+        seg = self._seg_in_slice()
+        # Each label_id has exactly 1 voxel in the seg and n_pixels=500, so
+        # overlap = 1/500 = 0.002.  Use a very small threshold so all pass.
+        result_low = self.fn(
+            self.table, reference_position="mid", slice_thickness=40.0,
+            segmentation=seg, voxel_size=self.voxel_size, min_overlap_fraction=1 / 500,
+        )
+        self.assertEqual(result_low["n_sgns"], 20)
+
+    def test_all_excluded_when_outside_slice(self):
+        seg = self._seg_out_of_slice()
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = self.fn(
+                self.table, reference_position="mid", slice_thickness=40.0,
+                segmentation=seg, voxel_size=self.voxel_size, min_overlap_fraction=1 / 500,
+            )
+        self.assertEqual(result["n_sgns"], 0)
+
+    def test_partial_overlap_threshold(self):
+        # Build a seg where only label_ids 1–10 are painted (first half of table).
+        partial_table = self.table.iloc[:10]
+        seg = _make_seg_array(partial_table, self.shape_zyx, self.voxel_size)
+        result = self.fn(
+            self.table, reference_position="mid", slice_thickness=40.0,
+            segmentation=seg, voxel_size=self.voxel_size, min_overlap_fraction=1 / 500,
+        )
+        self.assertEqual(result["n_sgns"], 10)
+
+    def test_no_filtering_when_none(self):
+        # Without segmentation, result is the same as before (20 SGNs).
+        result = self.fn(
+            self.table, reference_position="mid", slice_thickness=40.0,
+            min_overlap_fraction=None,
+        )
+        self.assertEqual(result["n_sgns"], 20)
+
+    def test_result_includes_min_overlap_key(self):
+        seg = self._seg_in_slice()
+        result = self.fn(
+            self.table, reference_position="mid", slice_thickness=40.0,
+            segmentation=seg, voxel_size=self.voxel_size, min_overlap_fraction=0.002,
+        )
+        self.assertIn("min_overlap_fraction", result)
+        self.assertAlmostEqual(result["min_overlap_fraction"], 0.002)
+
+    def test_min_overlap_fraction_none_in_result_when_not_used(self):
+        result = self.fn(self.table, reference_position="mid")
+        self.assertIn("min_overlap_fraction", result)
+        self.assertIsNone(result["min_overlap_fraction"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**SGN density calculation along Rosenthal's Canal**

Adds functions and a CLI command to compute spiral ganglion neuron (SGN) density at defined cochlear positions from a tonotopically mapped segmentation table.

**New module**: `flamingo_tools/analysis/density_utils.py`

- `sgn_density_at_position` — selects all SGN instances whose bounding boxes overlap a slice of configurable thickness centred on a target `length_fraction`, applies a run-length tolerance filter to reject instances from other cochlear turns, and computes density as SGN count divided by the convex-hull area (2D mode,
SGN/µm²) or convex-hull volume (3D mode, SGN/µm³). Returns a result dict including the 3D bounding box of the selected instances for downstream visualisation.
- `sgn_density_profile` — calls `sgn_density_at_position` for a list of positions (default: `apex`, `mid`, `base`).
- `calc_sgn_density` — top-level function used by the CLI; resolves the table path from a ChReef-format input JSON, loads the segmentation if overlap filtering is requested, runs `sgn_density_profile`, writes density results as JSON, and optionally writes a block-extraction JSON for `flamingo_tools.extract_block`.
- `_build_block_extraction_dict` — converts density results into a list of per-position dicts compatible with `flamingo_tools.extract_block --json_info`. The `roi_halo` is either taken from the input JSON / explicit argument or auto-computed: `ceil(slice_thickness / 2 / voxel_size)` along the slice axis and bounding-box
half-extents along the two projection axes.
- `_filter_by_segmentation_overlap` — optional post-filter that loads a slab of the segmentation volume (zarr or numpy, `Z×Y×X`), counts voxels per label using `skimage.measure.regionprops`, and keeps only instances where `voxels_in_slice / n_pixels ≥ min_overlap_fraction`. Automatically distinguishes a full OME-ZARR
volume from a pre-extracted crop by comparing the array's physical extent to the maximum anchor coordinate in the table — no offset parameter required.

**CLI**: `flamingo_tools.sgn_density` (`flamingo_tools/postprocessing/cli.py`, `setup.py`)

New entry point wrapping `calc_sgn_density` with arguments for:
- Table input (`-i`) or ChReef JSON input (`-j`) with auto-derived table and segmentation paths
- Positions, slice thickness, run-length tolerance, axis, density mode (2D/3D)
- JSON output for block extraction (`--json_output`) with automatic or explicit `roi_halo`
- Segmentation overlap filtering (`--seg_path`, `--seg_key`, `--min_overlap_fraction`)
- Full S3 support (`--s3`, `--s3_credentials`, `--s3_bucket_name`, `--s3_service_endpoint`)

**Documentation**: Changes are documented in `doc/sgn_density.md`

**Tests**: `test/test_density_utils.py`

42 unit tests covering `sgn_density_at_position`, `sgn_density_profile`, `_build_block_extraction_dict`, and `_filter_by_segmentation_overlap`, including auto roi-halo computation, segmentation overlap filtering, and crop vs. full-volume auto-detection.