### PR TITLE
Hull for SGN density, filter based on minimal SGN volume

### DIFF
--- a/flamingo_tools/analysis/density_utils.py
+++ b/flamingo_tools/analysis/density_utils.py
@@ -43,6 +43,7 @@ def sgn_density_at_position(
     segmentation=None,
     voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
     min_overlap_fraction: Optional[float] = None,
+    min_overlap_volume: Optional[float] = None,
 ) -> dict:
     """Calculate SGN density at a specific cochlear position using a planar slice.
 
@@ -80,25 +81,35 @@ def sgn_density_at_position(
                               must lie within the slice for the instance to be counted. Only
                               active when `segmentation` is also provided. Default None
                               (no segmentation-based filtering).
+        min_overlap_volume: Alternative to `min_overlap_fraction`: minimum overlap expressed
+                            as an absolute voxel volume in µm³. Exactly one of the two
+                            overlap parameters may be set. Default None.
+
     Returns:
         dict with keys:
-            reference_fraction  - resolved fraction used as the target position
-            reference_label_id  - label_id of the SGN instance nearest to that fraction
-            slice_center        - anchor coordinate along `axis` for the reference (µm)
-            slice_min           - lower bound of the slice window (µm)
-            slice_max           - upper bound of the slice window (µm)
-            slice_thickness     - slice thickness used (µm)
-            n_sgns              - number of SGNs counted in the slice
-            area                - convex-hull cross-sectional area (µm²); only in mode='2d'
-            volume              - convex-hull volume (µm³); only in mode='3d'
-            density             - n_sgns / area (mode='2d') or n_sgns / volume (mode='3d')
-            mode                - density mode used ('2d' or '3d')
-            axis                - axis used for slicing
-            bb_min              - [x, y, z] lower corner of 3D bounding box (µm)
-            bb_max              - [x, y, z] upper corner of 3D bounding box (µm)
-            bb_center           - [x, y, z] center of 3D bounding box (µm); pass as `coords`
-                                  to flamingo_tools.extract_block for block visualisation
+            reference_fraction   - resolved fraction used as the target position
+            reference_label_id   - label_id of the SGN instance nearest to that fraction
+            slice_center         - anchor coordinate along `axis` for the reference (µm)
+            slice_min            - lower bound of the slice window (µm)
+            slice_max            - upper bound of the slice window (µm)
+            slice_thickness      - slice thickness used (µm)
+            n_sgns               - number of SGNs counted in the slice
+            area                 - convex-hull cross-sectional area (µm²); only in mode='2d'
+            volume               - convex-hull volume (µm³); only in mode='3d'
+            density              - n_sgns / area (mode='2d') or n_sgns / volume (mode='3d')
+            mode                 - density mode used ('2d' or '3d')
+            axis                 - axis used for slicing
+            bb_min               - [x, y, z] lower corner of 3D bounding box (µm)
+            bb_max               - [x, y, z] upper corner of 3D bounding box (µm)
+            bb_center            - [x, y, z] center of 3D bounding box (µm); pass as `coords`
+                                   to flamingo_tools.extract_block for block visualisation
             min_overlap_fraction - value passed in (or None when not used)
+            min_overlap_volume   - value passed in (or None when not used)
+            hull_vertices        - list of anchor coordinates (µm) forming the convex hull
+                                   boundary; shape (k, 2) for mode='2d' (projection axes),
+                                   (k, 3) for mode='3d' (x/y/z). None when the hull could
+                                   not be computed. Pass to `hull_to_mask` to generate a
+                                   binary napari-compatible mask for the density region.
     """
     if axis not in _AXIS_PROJECTION:
         raise ValueError(f"axis must be one of {list(_AXIS_PROJECTION)}, got '{axis}'")
@@ -154,14 +165,18 @@ def sgn_density_at_position(
         (in_slice[length_fraction_column] - ref_frac).abs() <= run_length_tolerance
     ]
 
+    filtered_labels = []
     # Optional: filter by actual voxel overlap with the slice sub-volume.
-    if segmentation is not None and min_overlap_fraction is not None:
-        in_slice = _filter_by_segmentation_overlap(
+    if segmentation is not None and (min_overlap_fraction is not None or min_overlap_volume is not None):
+        in_slice, filtered_out = _filter_by_segmentation_overlap(
             in_slice, segmentation, slice_min, slice_max,
-            axis, voxel_size, min_overlap_fraction,
+            axis, voxel_size, min_overlap_fraction=min_overlap_fraction,
+            min_overlap_volume=min_overlap_volume,
         )
+        filtered_labels = list(filtered_out["label_id"]),
 
     n_sgns = len(in_slice)
+    labels_in = [int(i) for i in list(in_slice["label_id"])]
 
     # Compute extent (area in 2D, volume in 3D) via convex hull.
     if mode == "2d":
@@ -172,7 +187,7 @@ def sgn_density_at_position(
         hull_coords = in_slice[["anchor_x", "anchor_y", "anchor_z"]].values
         extent_key = "volume"
 
-    extent = _compute_hull_extent(hull_coords)
+    extent, hull_vertices = _compute_hull(hull_coords)
     density = n_sgns / extent if extent > 0 else float("nan")
 
     # 3D bounding box covering all selected SGN instance bounding boxes.
@@ -206,31 +221,39 @@ def sgn_density_at_position(
         "bb_min": bb_min,
         "bb_max": bb_max,
         "bb_center": bb_center,
+        "label_ids": labels_in,
+        "label_removed": filtered_labels,
         "min_overlap_fraction": min_overlap_fraction,
+        "min_overlap_volume": min_overlap_volume,
+        "hull_vertices": hull_vertices.tolist() if hull_vertices is not None else None,
     }
 
 
-def _compute_hull_extent(coords: np.ndarray) -> float:
-    """Return convex hull area (2D input) or volume (3D input); falls back to bounding box."""
+def _compute_hull(coords: np.ndarray) -> Tuple[float, Optional[np.ndarray]]:
+    """Return (extent, hull_vertices) for the given anchor coordinates.
+
+    extent is the convex-hull area (2D input) or volume (3D input) in µm²/µm³.
+    hull_vertices is the subset of `coords` that form the hull, shape (k, ndim), in µm.
+    Returns (fallback_extent, None) when the hull cannot be computed.
+    """
     if len(coords) == 0:
         warnings.warn("No SGN instances in slice; extent is 0.", stacklevel=3)
-        return 0.0
+        return 0.0, None
 
     ndim = coords.shape[1]
-    min_pts = ndim + 1  # 3 for 2D, 4 for 3D
-    if len(coords) < min_pts:
+    if len(coords) < ndim + 1:
         warnings.warn(
             f"Only {len(coords)} SGN instance(s) in slice; falling back to bounding-box extent.",
             stacklevel=3,
         )
-        return _bbox_extent(coords)
+        return _bbox_extent(coords), None
 
     try:
         hull = ConvexHull(coords)
-        return float(hull.volume)  # area for 2D input, volume for 3D input
+        return float(hull.volume), coords[hull.vertices]  # area for 2D, volume for 3D
     except Exception:
         warnings.warn("ConvexHull failed; falling back to bounding-box extent.", stacklevel=3)
-        return _bbox_extent(coords)
+        return _bbox_extent(coords), None
 
 
 def _bbox_extent(coords: np.ndarray) -> float:
@@ -251,7 +274,8 @@ def _filter_by_segmentation_overlap(
     slice_max: float,
     axis: str,
     voxel_size: Tuple[float, float, float],
-    min_overlap_fraction: float,
+    min_overlap_fraction: Optional[float] = None,
+    min_overlap_volume: Optional[float] = None,
 ) -> pd.DataFrame:
     """Filter SGN instances by their voxel overlap with the slice sub-volume.
 
@@ -282,6 +306,9 @@ def _filter_by_segmentation_overlap(
     dim = _AXIS_ZYX_DIM[axis]
     vs_a = voxel_size[phys_index]
 
+    if min_overlap_fraction is not None and min_overlap_volume is not None:
+        raise ValueError("Choose either a minimal overlap fraction or a minimal volume [µm³], not both.")
+
     # Auto-detect crop vs. full volume: if the array's physical extent along the slice axis
     # is smaller than the maximum anchor coordinate in the table, the array is a crop and
     # all of its voxels are already within the region of interest.
@@ -302,14 +329,24 @@ def _filter_by_segmentation_overlap(
     label_ids = table["label_id"].astype(int).values
     n_pixels = table["n_pixels"].astype(int).values
     vox_in_slice = np.array([voxels_in_slice.get(lid, 0) for lid in label_ids])
-    overlap = np.where(n_pixels > 0, vox_in_slice / n_pixels, 0.0)
-    filtered = table[overlap >= min_overlap_fraction]
+    if min_overlap_fraction is not None:
+        overlap = np.where(n_pixels > 0, vox_in_slice / n_pixels, 0.0)
+        filtered = table[overlap >= min_overlap_fraction]
+        filtered_out = table[overlap < min_overlap_fraction]
+    elif min_overlap_volume is not None:
+        voxel_vol = voxel_size[0] * voxel_size[1] * voxel_size[2]
+        volume_in_slice = vox_in_slice * voxel_vol
+        filtered = table[volume_in_slice >= min_overlap_volume]
+        filtered_out = table[volume_in_slice < min_overlap_volume]
+    else:
+        raise ValueError("Choose a minimal overlap to exclude instances.")
+
     if filtered.empty:
         warnings.warn(
             "All SGN instances were removed by the segmentation overlap filter.",
             stacklevel=4,
         )
-    return filtered
+    return filtered, filtered_out
 
 
 def sgn_density_profile(
@@ -324,6 +361,7 @@ def sgn_density_profile(
     segmentation=None,
     voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
     min_overlap_fraction: Optional[float] = None,
+    min_overlap_volume: Optional[float] = None,
 ) -> dict:
     """Compute SGN density at multiple cochlear positions.
 
@@ -363,6 +401,7 @@ def sgn_density_profile(
             segmentation=segmentation,
             voxel_size=voxel_size,
             min_overlap_fraction=min_overlap_fraction,
+            min_overlap_volume=min_overlap_volume,
         )
     return results
 
@@ -373,7 +412,7 @@ def _auto_roi_halo(
     voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
     axis: str = "z",
     slice_thickness: Optional[float] = None,
-    min_halo: int = 10,
+    min_halo: int = 1,
 ) -> List[int]:
     """Compute roi_halo in pixels sized to match the slice exactly.
 
@@ -472,10 +511,87 @@ def _build_block_extraction_dict(
                 axis=pos_result.get("axis", "z"),
                 slice_thickness=pos_result.get("slice_thickness"),
             )
+            entry["label_ids"] = pos_result.get("label_ids"),
+            entry["label_removed"] = pos_result.get("label_removed"),
+            entry["hull_vertices"] = pos_result.get("hull_vertices"),
 
         result_list.append(entry)
 
     return result_list
+
+
+def hull_to_mask(
+    hull_vertices: Union[List, np.ndarray],
+    bb_center: List[float],
+    roi_halo: List[int],
+    voxel_size: Tuple[float, float, float],
+    axis: str = "z",
+    mode: str = "2d",
+    **_,
+) -> np.ndarray:
+    """Convert convex hull vertices to a binary ZYX mask aligned with an extracted crop.
+
+    The returned mask has the same spatial extent as a crop produced by
+    `flamingo_tools.extract_block` with the given `bb_center` and `roi_halo`, so it can be
+    loaded directly as a napari Labels layer alongside the image crop.
+
+    Args:
+        hull_vertices: Convex hull vertex coordinates in µm. Shape (N, 2) for mode='2d'
+                       (columns ordered as the two projection axes of `_AXIS_PROJECTION[axis]`,
+                       e.g. x/y for axis='z'). Shape (N, 3) for mode='3d' (x/y/z order).
+                       Typically the ``hull_vertices`` value from a `sgn_density_at_position`
+                       result dict.
+        bb_center: [x, y, z] physical centre of the crop in µm (``bb_center`` from the
+                   density result dict).
+        roi_halo: [halo_x, halo_y, halo_z] half-extents of the crop in pixels.
+        voxel_size: Voxel size in µm per axis (x, y, z order).
+        axis: Slice axis used for the density calculation ('x', 'y', or 'z'). Only
+              relevant in mode='2d' to determine the projection plane.
+        mode: '2d' rasterises the 2D polygon and extrudes it along the slice axis.
+              '3d' performs a half-space test for every voxel centre inside the crop.
+
+    Returns:
+        Boolean numpy array of shape (2*halo_z, 2*halo_y, 2*halo_x) — True inside the hull.
+    """
+    from skimage.draw import polygon as sk_polygon
+
+    verts = np.asarray(hull_vertices, dtype=float)
+    phys_idx = {"x": 0, "y": 1, "z": 2}
+    mask_shape_zyx = (2 * roi_halo[2], 2 * roi_halo[1], 2 * roi_halo[0])
+
+    if mode == "2d":
+        proj_ax0, proj_ax1 = _AXIS_PROJECTION[axis]
+        i0, i1 = phys_idx[proj_ax0], phys_idx[proj_ax1]
+
+        origin0 = bb_center[i0] - roi_halo[i0] * voxel_size[i0]
+        origin1 = bb_center[i1] - roi_halo[i1] * voxel_size[i1]
+
+        vert_col = (verts[:, 0] - origin0) / voxel_size[i0]
+        vert_row = (verts[:, 1] - origin1) / voxel_size[i1]
+        n_rows = 2 * roi_halo[i1]
+        n_cols = 2 * roi_halo[i0]
+        plane_mask = np.zeros((n_rows, n_cols), dtype=bool)
+        rr, cc = sk_polygon(vert_row, vert_col, shape=(n_rows, n_cols))
+        plane_mask[rr, cc] = True
+
+        # Extrude along the slice axis by inserting a broadcast dimension there.
+        slice_dim = _AXIS_ZYX_DIM[axis]
+        new_shape = list(plane_mask.shape)
+        new_shape.insert(slice_dim, 1)
+        return np.broadcast_to(plane_mask.reshape(new_shape), mask_shape_zyx).copy()
+
+    else:  # mode == "3d"
+        gx = (bb_center[0] - roi_halo[0] * voxel_size[0]) + np.arange(2 * roi_halo[0]) * voxel_size[0]
+        gy = (bb_center[1] - roi_halo[1] * voxel_size[1]) + np.arange(2 * roi_halo[1]) * voxel_size[1]
+        gz = (bb_center[2] - roi_halo[2] * voxel_size[2]) + np.arange(2 * roi_halo[2]) * voxel_size[2]
+
+        GZ, GY, GX = np.meshgrid(gz, gy, gx, indexing="ij")  # each (2hz, 2hy, 2hx)
+        pts = np.column_stack([GX.ravel(), GY.ravel(), GZ.ravel()])
+
+        hull = ConvexHull(verts)
+        # A point is inside the convex hull when all half-space constraints are satisfied.
+        inside = np.all(pts @ hull.equations[:, :3].T + hull.equations[:, 3] <= 0, axis=1)
+        return inside.reshape(mask_shape_zyx)
 
 
 def calc_sgn_density(
@@ -493,16 +609,17 @@ def calc_sgn_density(
     density_mode: str = "2d",
     roi_halo: Optional[List[int]] = None,
     voxel_size: Tuple[float, float, float] = (0.38, 0.38, 0.38),
-    mobie_dir: str = MOBIE_FOLDER,
+    mobie_dir: str = None,
     seg_path: Optional[str] = None,
     seg_key: str = "s0",
     min_overlap_fraction: Optional[float] = None,
+    min_overlap_volume: Optional[float] = None,
     s3: bool = False,
     s3_credentials: Optional[str] = None,
     s3_bucket_name: Optional[str] = None,
     s3_service_endpoint: Optional[str] = None,
 ):
-    """
+    """Calcualte SGN density for 2D and 3D sub-volumes.
 
     Args:
         output: Output path for JSON file with density results.
@@ -543,6 +660,7 @@ def calc_sgn_density(
                               Default: None (no segmentation-based filtering). Whether the
                               segmentation is a pre-extracted crop or a full volume is detected
                               automatically from the array shape.
+        min_overlap_volume: Analogous to min_overlap_fraction with explicit volume in µm³
         s3: Flag for accessing data stored on S3 bucket.
         s3_credentials: File path to credentials for S3 bucket.
         s3_bucket_name: S3 bucket name.
@@ -556,6 +674,9 @@ def calc_sgn_density(
         if isinstance(json_params, list):
             json_params = json_params[0]
 
+    if mobie_dir is None:
+        mobie_dir = os.getcwd()
+
     if seg_table_path is not None:
         table_path = seg_table_path
     elif json_params is not None:
@@ -565,6 +686,8 @@ def calc_sgn_density(
             table_path = f"{dataset_name}/tables/{seg_channel}/default.tsv"
         else:
             table_path = os.path.join(mobie_dir, dataset_name, "tables", seg_channel, "default.tsv")
+            if not os.path.isfile(table_path):
+                raise ValueError(f"Table path {table_path} does not exist. Use explicit path or check MoBIE folder.")
     else:
         raise ValueError("Provide 'seg_table_path' or 'json_input'.")
 
@@ -595,7 +718,7 @@ def calc_sgn_density(
 
     # Resolve and load segmentation if overlap filtering is requested.
     segmentation = None
-    if min_overlap_fraction is not None:
+    if min_overlap_fraction is not None or min_overlap_volume is not None:
         if seg_path is None and json_params is not None:
             dataset_name = json_params["dataset_name"]
             seg_channel = json_params.get("segmentation_channel", "SGN_v2")
@@ -627,6 +750,7 @@ def calc_sgn_density(
         segmentation=segmentation,
         voxel_size=voxel_size,
         min_overlap_fraction=min_overlap_fraction,
+        min_overlap_volume=min_overlap_volume,
     )
 
     export_dictionary_as_json(results, output, force_overwrite=force_overwrite)

--- a/flamingo_tools/extract_block_util.py
+++ b/flamingo_tools/extract_block_util.py
@@ -13,6 +13,7 @@ from skimage.transform import rescale
 from flamingo_tools.file_utils import read_image_data
 from flamingo_tools.s3_utils import get_s3_path, MOBIE_FOLDER
 from flamingo_tools.postprocessing.cochlea_mapping import equidistant_centers_single
+from flamingo_tools.analysis.density_utils import hull_to_mask
 
 
 def extract_block_single(
@@ -31,6 +32,7 @@ def extract_block_single(
     s3_service_endpoint: Optional[str] = None,
     scale_factor: Optional[Tuple[float, float, float]] = None,
     force_overwrite: bool = False,
+    label_ids: Optional[List[int]] = None,
     **_,
 ) -> None:
     """Extract block around coordinate from input data according to a given halo.
@@ -114,6 +116,63 @@ def extract_block_single(
         f_out = zarr.open(output_path, mode="w")
         f_out.create_dataset(output_key, data=data_roi, compression="gzip")
 
+    # filter out segmentation not corresponding to label IDs
+    if label_ids is not None:
+        # check for segmentation
+        if data_roi.dtype in (np.dtype("int32"), np.dtype("uint32"), np.dtype("int64"), np.dtype("uint64")):
+            print("Filtering segmentation with label IDs.")
+            filter_mask = ~np.isin(data_roi, label_ids)
+            if np.count_nonzero(data_roi[filter_mask]) != 0:
+                data_roi[filter_mask] = 0
+                output_path = os.path.splitext(output_path)[0] + "_filtered" + os.path.splitext(output_path)[1]
+                imageio.imwrite(output_path, data_roi, compression="zlib")
+
+
+def save_mask_from_hull_vertices(
+    coords: List[int],
+    hull_vertices: List[List[float]],
+    output_path: Optional[str] = None,
+    dataset_name: Optional[str] = None,
+    voxel_size: Union[float, Tuple[float, float, float]] = 0.38,
+    roi_halo: List[int] = [128, 128, 64],
+    **_,
+) -> None:
+    """Extract block around coordinate from input data according to a given halo.
+    Either from a local file or from an S3 bucket.
+
+    Args:
+        input_path: Input folder in n5 / ome-zarr format.
+        coords: Center coordinates of extracted 3D volume.
+        output_dir: Output directory for saving output as <basename>_crop.n5. Default: input directory.
+        output_path: Output directory or file for saving output as <basename>_crop.n5. Default: input directory.
+        input_key: Input key for data in input file.
+        output_key: Output key for data in n5 format. If None is supplied, output is TIF file.
+        voxel_size: The voxel size of the data in micrometer.
+        roi_halo: ROI halo of extracted 3D volume.
+        s3: Flag for accessing data stored on S3 bucket.
+        s3_credentials: File path to credentials for S3 bucket.
+        s3_bucket_name: S3 bucket name.
+        s3_service_endpoint: S3 service endpoint.
+        scale_factor: Optional factor for rescaling the extracted data.
+        force_overwrite: Flag for forcefully overwriting output files.
+    """
+    coord_string = "-".join([str(int(round(c))).zfill(4) for c in coords])
+    density_mask = hull_to_mask(
+        hull_vertices[0],
+        bb_center=coords,
+        roi_halo=roi_halo,
+        voxel_size=voxel_size,
+    )
+    prefix = ""
+    if dataset_name is not None:
+        dataset_str = dataset_name.replace('_', '-')
+        prefix = f"{dataset_str}_"
+    coord_string = "-".join([str(int(round(c))).zfill(4) for c in coords])
+    output_name = f"{prefix}crop_{coord_string}_hull.tif"
+    output_path = os.path.join(output_path, output_name)
+
+    imageio.imwrite(output_path, density_mask, compression="zlib")
+
 
 def extract_block_json_wrapper(
     output_path: str,
@@ -166,6 +225,11 @@ def extract_block_json_wrapper(
                         s3=s3,
                         **kwargs,
                     )
+
+            # crop out mask from hull vertices
+            if "hull_vertices" in list(params.keys()):
+                for coords in params["crop_centers"]:
+                    save_mask_from_hull_vertices(coords=coords, output_path=output_path, **kwargs)
 
     else:
         if input_path is None:

--- a/flamingo_tools/postprocessing/cli.py
+++ b/flamingo_tools/postprocessing/cli.py
@@ -407,9 +407,9 @@ def sgn_density():
         "Default: 0.38 0.38 0.38",
     )
     parser.add_argument(
-        "--mobie_dir", type=str, default=MOBIE_FOLDER,
+        "--mobie_dir", type=str, default=None,
         help="Local MoBIE project directory used to locate the table when --json_input is given "
-        "and --input is absent.",
+        "and --input is absent. Default: Current directory",
     )
     parser.add_argument(
         "--seg_path", type=str, default=None,
@@ -426,6 +426,13 @@ def sgn_density():
         "--min_overlap_fraction", type=float, default=None,
         help="Minimum fraction of an SGN's voxels (n_pixels) that must lie within the "
         "slice sub-volume to count the instance. Range (0, 1]. "
+        "Default: None (no segmentation-based filtering). "
+        "Whether --seg_path is a pre-extracted crop or a full volume is detected automatically.",
+    )
+    parser.add_argument(
+        "--min_overlap_volume", type=float, default=None,
+        help="Minimum volume[µm³] of an SGN's voxels (n_pixels) that must lie within the "
+        "slice sub-volume to count the instance. "
         "Default: None (no segmentation-based filtering). "
         "Whether --seg_path is a pre-extracted crop or a full volume is detected automatically.",
     )
@@ -464,6 +471,7 @@ def sgn_density():
         seg_path=args.seg_path,
         seg_key=args.seg_key,
         min_overlap_fraction=args.min_overlap_fraction,
+        min_overlap_volume=args.min_overlap_volume,
         s3=args.s3,
         s3_credentials=args.s3_credentials,
         s3_bucket_name=args.s3_bucket_name,

--- a/test/test_density_utils.py
+++ b/test/test_density_utils.py
@@ -108,7 +108,8 @@ class TestSgnDensityAtPosition(unittest.TestCase):
             "reference_fraction", "reference_label_id", "slice_center",
             "slice_min", "slice_max", "slice_thickness", "n_sgns",
             "area", "density", "mode", "axis",
-            "bb_min", "bb_max", "bb_center", "min_overlap_fraction",
+            "bb_min", "bb_max", "bb_center",
+            "min_overlap_fraction", "min_overlap_volume", "hull_vertices",
         }
         self.assertEqual(set(result.keys()), expected)
         self.assertNotIn("volume", result)
@@ -119,7 +120,8 @@ class TestSgnDensityAtPosition(unittest.TestCase):
             "reference_fraction", "reference_label_id", "slice_center",
             "slice_min", "slice_max", "slice_thickness", "n_sgns",
             "volume", "density", "mode", "axis",
-            "bb_min", "bb_max", "bb_center", "min_overlap_fraction",
+            "bb_min", "bb_max", "bb_center",
+            "min_overlap_fraction", "min_overlap_volume", "hull_vertices",
         }
         self.assertEqual(set(result.keys()), expected)
         self.assertNotIn("area", result)
@@ -396,6 +398,24 @@ class TestFilterBySegmentationOverlap(unittest.TestCase):
         self.assertIn("min_overlap_fraction", result)
         self.assertIsNone(result["min_overlap_fraction"])
 
+    def test_min_overlap_volume_filters(self):
+        # n_pixels=500, voxel_size=1.0 → one voxel = 1 µm³, threshold=0.5 µm³ should keep all.
+        seg = self._seg_in_slice()
+        result = self.fn(
+            self.table, reference_position="mid", slice_thickness=40.0,
+            segmentation=seg, voxel_size=self.voxel_size, min_overlap_volume=0.5,
+        )
+        self.assertEqual(result["n_sgns"], 20)
+        # Threshold above 1 µm³ (each label has exactly 1 voxel = 1 µm³) → all excluded.
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result_excl = self.fn(
+                self.table, reference_position="mid", slice_thickness=40.0,
+                segmentation=seg, voxel_size=self.voxel_size, min_overlap_volume=2.0,
+            )
+        self.assertEqual(result_excl["n_sgns"], 0)
+
     def test_crop_auto_detection(self):
         # Build a small crop array whose z-extent (40 µm) is less than the max anchor
         # coordinate (~53 µm), triggering the crop-detection path.  Labels are painted
@@ -411,6 +431,75 @@ class TestFilterBySegmentationOverlap(unittest.TestCase):
             segmentation=seg, voxel_size=self.voxel_size, min_overlap_fraction=1 / 500,
         )
         self.assertEqual(result["n_sgns"], 20)
+
+
+class TestHullToMask(unittest.TestCase):
+
+    def setUp(self):
+        from flamingo_tools.analysis.density_utils import sgn_density_at_position, hull_to_mask
+        self.density_fn = sgn_density_at_position
+        self.mask_fn = hull_to_mask
+        self.table = _make_table(n=20, z_center=50.0, frac_center=0.5, frac_spread=0.05)
+        self.voxel_size = (1.0, 1.0, 1.0)
+        self.roi_halo = [40, 50, 30]  # [hx, hy, hz]
+
+    def _density_result(self, mode="2d"):
+        return self.density_fn(
+            self.table, reference_position="mid", slice_thickness=40.0, mode=mode,
+        )
+
+    def test_2d_mask_shape(self):
+        result = self._density_result(mode="2d")
+        mask = self.mask_fn(
+            result["hull_vertices"], result["bb_center"],
+            self.roi_halo, self.voxel_size, axis="z", mode="2d",
+        )
+        hz, hy, hx = self.roi_halo[2], self.roi_halo[1], self.roi_halo[0]
+        self.assertEqual(mask.shape, (2 * hz, 2 * hy, 2 * hx))
+
+    def test_2d_mask_nonzero(self):
+        result = self._density_result(mode="2d")
+        mask = self.mask_fn(
+            result["hull_vertices"], result["bb_center"],
+            self.roi_halo, self.voxel_size, axis="z", mode="2d",
+        )
+        self.assertTrue(mask.any())
+
+    def test_2d_mask_extruded_uniformly(self):
+        # For axis="z" every z-slice must be identical (the 2D polygon extruded along z).
+        result = self._density_result(mode="2d")
+        mask = self.mask_fn(
+            result["hull_vertices"], result["bb_center"],
+            self.roi_halo, self.voxel_size, axis="z", mode="2d",
+        )
+        for zi in range(mask.shape[0]):
+            np.testing.assert_array_equal(mask[zi], mask[0])
+
+    def test_3d_mask_shape(self):
+        result = self._density_result(mode="3d")
+        mask = self.mask_fn(
+            result["hull_vertices"], result["bb_center"],
+            self.roi_halo, self.voxel_size, axis="z", mode="3d",
+        )
+        hz, hy, hx = self.roi_halo[2], self.roi_halo[1], self.roi_halo[0]
+        self.assertEqual(mask.shape, (2 * hz, 2 * hy, 2 * hx))
+
+    def test_3d_mask_nonzero(self):
+        result = self._density_result(mode="3d")
+        mask = self.mask_fn(
+            result["hull_vertices"], result["bb_center"],
+            self.roi_halo, self.voxel_size, axis="z", mode="3d",
+        )
+        self.assertTrue(mask.any())
+
+    def test_hull_vertices_none_when_too_few_points(self):
+        # A table with only 1 SGN cannot form a convex hull → hull_vertices must be None.
+        single = self.table.iloc[:1].copy()
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = self.density_fn(single, reference_position="mid", slice_thickness=40.0)
+        self.assertIsNone(result["hull_vertices"])
 
 
 if __name__ == "__main__":

--- a/test/test_density_utils.py
+++ b/test/test_density_utils.py
@@ -108,7 +108,7 @@ class TestSgnDensityAtPosition(unittest.TestCase):
             "reference_fraction", "reference_label_id", "slice_center",
             "slice_min", "slice_max", "slice_thickness", "n_sgns",
             "area", "density", "mode", "axis",
-            "bb_min", "bb_max", "bb_center",
+            "bb_min", "bb_max", "bb_center", "label_ids", "label_removed",
             "min_overlap_fraction", "min_overlap_volume", "hull_vertices",
         }
         self.assertEqual(set(result.keys()), expected)
@@ -120,7 +120,7 @@ class TestSgnDensityAtPosition(unittest.TestCase):
             "reference_fraction", "reference_label_id", "slice_center",
             "slice_min", "slice_max", "slice_thickness", "n_sgns",
             "volume", "density", "mode", "axis",
-            "bb_min", "bb_max", "bb_center",
+            "bb_min", "bb_max", "bb_center", "label_ids", "label_removed",
             "min_overlap_fraction", "min_overlap_volume", "hull_vertices",
         }
         self.assertEqual(set(result.keys()), expected)


### PR DESCRIPTION
**SGN density — volume overlap threshold, convex hull export, and hull mask generation**

`flamingo_tools/analysis/density_utils.py`

`min_overlap_volume` (new alternative to `min_overlap_fraction`): expresses the minimum voxel overlap as an absolute volume in µm³ rather than a fraction of `n_pixels`. The `_filter_by_segmentation_overlap` function now returns both the kept and removed sub-tables so callers can record which label IDs were excluded. The segmentation-loading block in `calc_sgn_density` now also activates for `min_overlap_volume`.

**Convex hull export**: `_compute_hull_extent` is replaced by `_compute_hull`, which returns `(extent, hull_vertices)`. The hull vertex coordinates (µm) are stored in the result dict under `hull_vertices` — shape `(k, 2)` for 2D mode (projection-plane axes) and `(k, 3)` for 3D mode. `None` is returned when the hull falls back to the bounding-box approximation. The result dict also now includes `label_ids` (instances counted) and label_removed (instances excluded by overlap filtering).

**hull_to_mask** (new public function): converts stored hull vertices into a boolean ZYX numpy array sized `(2·hz, 2·hy, 2·hx)` aligned with a crop extracted by `flamingo_tools.extract_block`. 2D mode rasterises the polygon with `skimage.draw.polygon` and extrudes it along the slice axis via a single broadcast. 3D mode performs a vectorised half-space test using `ConvexHull.equations` over a meshgrid of voxel centres.

**flamingo_tools/extract_block_util.py**

**save_mask_from_hull_vertices** (new function): takes the crop centre, `hull_vertices`, and `roi_halo` from the block-extraction JSON and writes a `_hull.tif` mask to the output directory.

**extract_block_json_wrapper**: automatically calls `save_mask_from_hull_vertices` for each position when `hull_vertices` is present in the JSON entry, so masks are created alongside image crops in one pass.

**extract_block_single**: accepts an optional `label_ids` list; when provided on a segmentation TIF it zeroes out all labels not in the list and writes a `_filtered` copy.

**flamingo_tools/postprocessing/cli.py**

`--min_overlap_volume` argument added to `flamingo_tools.sgn_density`.

**Tests** (`test/test_density_utils.py`)

49 tests total (+7 new): `test_min_overlap_volume_filters`, and `TestHullToMask` with six cases covering shape, non-zero content, uniform extrusion (2D), 3D mask, and the `hull_vertices is None` fallback for degenerate inputs.