### PR TITLE
Ihc segmentation gridsearch

### DIFF
--- a/flamingo_tools/segmentation/__init__.py
+++ b/flamingo_tools/segmentation/__init__.py
@@ -1,4 +1,5 @@
 """This module implements the functionality to run instance segmentation and detection for large volumetric data.
 """
 
+from .gridsearch import get_or_compute_best_params, gridsearch
 from .unet_prediction import run_unet_prediction

--- a/flamingo_tools/segmentation/gridsearch.py
+++ b/flamingo_tools/segmentation/gridsearch.py
@@ -1,0 +1,201 @@
+"""Gridsearch for IHC distance-watershed segmentation parameters.
+
+Predictions are computed once per image and kept in memory; the watershed
+step is then swept over all combinations of ``center_distance_threshold``,
+``boundary_distance_threshold``, and ``distance_smoothing``.  Per-image
+results are written as JSON so that interrupted runs can be resumed cheaply.
+"""
+import itertools
+import json
+import os
+from glob import glob
+
+import imageio.v3 as imageio
+import numpy as np
+from elf.evaluation.dice import symmetric_best_dice_score
+from tqdm import tqdm
+
+from flamingo_tools.segmentation.unet_prediction import distance_watershed_implementation, prediction_impl
+
+DEFAULT_GRID_SEARCH_VALUES = {
+    "center_distance_threshold": [0.4, 0.5, 0.6, 0.7],
+    "boundary_distance_threshold": [0.4, 0.5, 0.6, 0.7],
+    "distance_smoothing": [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+}
+
+_ANNOTATION_SUFFIX = "_annotations"
+
+
+def _find_image_label_pairs(val_dir, annotation_suffix=_ANNOTATION_SUFFIX):
+    """Return sorted list of (image_path, label_path) TIF pairs from *val_dir*."""
+    all_tifs = sorted(glob(os.path.join(val_dir, "*.tif")))
+    pairs = []
+    for path in all_tifs:
+        stem = os.path.splitext(os.path.basename(path))[0]
+        if stem.endswith(annotation_suffix):
+            continue
+        label_path = os.path.join(val_dir, stem + annotation_suffix + ".tif")
+        if os.path.exists(label_path):
+            pairs.append((path, label_path))
+    return pairs
+
+
+def gridsearch(
+    val_dir,
+    model_path,
+    result_dir=None,
+    annotation_suffix=_ANNOTATION_SUFFIX,
+    grid_search_values=None,
+    block_shape=None,
+    halo=None,
+    min_size=0,
+    fg_threshold=0.5,
+):
+    """Find watershed parameters that maximise symmetric best-Dice on a validation set.
+
+    For each TIF image in *val_dir* (paired with ``<stem>_annotations.tif``),
+    the model prediction is computed once and held in memory.  The watershed is
+    then applied for every combination of gridsearch parameters, scored with
+    :func:`elf.evaluation.dice.symmetric_best_dice_score`, and the result is
+    written to ``<result_dir>/<image_stem>.json``.  Existing JSON files are
+    re-used so the gridsearch can be resumed after interruption.
+
+    Args:
+        val_dir: Directory containing TIF image / annotation pairs.
+        model_path: Path to the model checkpoint or exported model file.
+        result_dir: Directory for per-image JSON result files.  No files are
+            written when ``None``.
+        annotation_suffix: Suffix that distinguishes label files from image
+            files (default ``"_annotations"``).
+        grid_search_values: Dict mapping parameter names to lists of values to
+            sweep.  Defaults to :data:`DEFAULT_GRID_SEARCH_VALUES`.
+        block_shape: Block shape for tiled prediction (auto-detected when None).
+        halo: Halo for tiled prediction (auto-detected when None).
+        min_size: Minimum object size passed to the watershed (default 0).
+        fg_threshold: Foreground threshold for the watershed mask.
+
+    Returns:
+        Tuple ``(best_params, best_score)`` where *best_params* is a dict of
+        parameter names to values and *best_score* is the mean
+        symmetric-best-Dice across all validation images.
+    """
+    if grid_search_values is None:
+        grid_search_values = DEFAULT_GRID_SEARCH_VALUES
+
+    if result_dir is not None:
+        os.makedirs(result_dir, exist_ok=True)
+
+    pairs = _find_image_label_pairs(val_dir, annotation_suffix)
+    if not pairs:
+        raise ValueError(f"No image/label TIF pairs found in {val_dir!r} (annotation suffix: {annotation_suffix!r})")
+
+    param_names = list(grid_search_values.keys())
+    combos = list(itertools.product(*[grid_search_values[k] for k in param_names]))
+    print(
+        f"Gridsearch: {len(combos)} parameter combinations x {len(pairs)} images "
+        f"= {len(combos) * len(pairs)} evaluations"
+    )
+
+    # records: list of dicts {param_key_0: v0, ..., "dice": score} per image per combo
+    all_records = []
+
+    for image_path, label_path in pairs:
+        image_stem = os.path.splitext(os.path.basename(image_path))[0]
+
+        if result_dir is not None:
+            cache_path = os.path.join(result_dir, f"{image_stem}.json")
+            if os.path.exists(cache_path):
+                print(f"  {image_stem}: loading cached results from {cache_path}")
+                with open(cache_path) as fh:
+                    image_records = json.load(fh)
+                all_records.extend(image_records)
+                continue
+
+        print(f"\n{image_stem}: running prediction ...")
+        _, prediction = prediction_impl(
+            image_path, None, None, model_path,
+            scale=None, block_shape=block_shape, halo=halo,
+            apply_postprocessing=False, output_channels=3,
+        )
+
+        gt = imageio.imread(label_path)
+
+        image_records = []
+        for combo in tqdm(combos, desc=f"  {image_stem} sweep"):
+            params = dict(zip(param_names, combo))
+            seg = distance_watershed_implementation(
+                prediction,
+                output_folder=None,
+                min_size=min_size,
+                fg_threshold=fg_threshold,
+                **params,
+            )
+            score = symmetric_best_dice_score(seg, gt)
+            image_records.append({**params, "dice": float(score)})
+
+        if result_dir is not None:
+            with open(cache_path, "w") as fh:
+                json.dump(image_records, fh, indent=2)
+
+        all_records.extend(image_records)
+
+    # Average dice over images for each parameter combination.
+    combo_totals = {}
+    combo_counts = {}
+    for record in all_records:
+        key = tuple(record[k] for k in param_names)
+        combo_totals[key] = combo_totals.get(key, 0.0) + record["dice"]
+        combo_counts[key] = combo_counts.get(key, 0) + 1
+
+    best_key = max(combo_totals, key=lambda k: combo_totals[k] / combo_counts[k])
+    best_params = dict(zip(param_names, best_key))
+    best_score = combo_totals[best_key] / combo_counts[best_key]
+
+    print(f"\nBest parameters: {best_params}")
+    print(f"Mean symmetric best-Dice: {best_score:.4f}")
+    return best_params, float(best_score)
+
+
+def get_or_compute_best_params(
+    model_path,
+    val_dir,
+    annotation_suffix=_ANNOTATION_SUFFIX,
+    grid_search_values=None,
+    **gridsearch_kwargs,
+):
+    """Return the cached best watershed parameters for *model_path*, running gridsearch if needed.
+
+    The result is stored as ``<model_path_without_extension>_best_params.json``
+    alongside the model file.  Subsequent calls skip the gridsearch and return
+    the cached values immediately.
+
+    Args:
+        model_path: Path to the model file (used as the cache key).
+        val_dir: Directory containing TIF image / annotation pairs.
+        annotation_suffix: Suffix distinguishing label files from image files.
+        grid_search_values: Parameter sweep dict forwarded to :func:`gridsearch`.
+        **gridsearch_kwargs: Additional keyword arguments forwarded to
+            :func:`gridsearch` (e.g. ``block_shape``, ``halo``, ``min_size``).
+
+    Returns:
+        Tuple ``(best_params, best_score)``.
+    """
+    cache_path = os.path.splitext(model_path)[0] + "_best_params.json"
+
+    if os.path.exists(cache_path):
+        with open(cache_path) as fh:
+            data = json.load(fh)
+        print(f"Loaded cached best params from {cache_path}")
+        return data["params"], data["score"]
+
+    best_params, best_score = gridsearch(
+        val_dir, model_path,
+        annotation_suffix=annotation_suffix,
+        grid_search_values=grid_search_values,
+        **gridsearch_kwargs,
+    )
+
+    with open(cache_path, "w") as fh:
+        json.dump({"params": best_params, "score": best_score}, fh, indent=2)
+    print(f"Best params saved to {cache_path}")
+    return best_params, best_score

--- a/scripts/prediction/gridsearch_ihc.py
+++ b/scripts/prediction/gridsearch_ihc.py
@@ -1,0 +1,49 @@
+"""Prediction using distance U-Net.
+Parallelization using multiple GPUs is currently only possible
+by calling functions located in segmentation/unet_prediction.py directly.
+Functions for the parallelization end with '_slurm' and divide the process into preprocessing,
+prediction, and segmentation.
+"""
+import argparse
+import json
+import time
+import os
+
+import imageio.v3 as imageio
+import torch
+import z5py
+
+from flamingo_tools.segmentation.gridsearch import gridsearch
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--input", required=True)
+    parser.add_argument("-o", "--output_folder", required=True)
+    parser.add_argument("-m", "--model", required=True)
+    parser.add_argument("-b", "--block_shape", default=None, type=str)
+    parser.add_argument("--halo", default=None, type=str)
+    parser.add_argument("--seg_class", default=None, type=str,
+                        help="Segmentation class to load parameters for masking input.")
+    parser.add_argument("--center_distance_threshold", default=0.4, type=float,
+                        help="The threshold applied to the distance center predictions to derive seeds.")
+    parser.add_argument("--boundary_distance_threshold", default=None, type=float,
+                        help="The threshold applied to the boundary predictions to derive seeds. \
+                        By default this is set to 'None', \
+                        in which case the boundary distances are not used for the seeds.")
+    parser.add_argument("--fg_threshold", default=0.5, type=float,
+                        help="The threshold applied to the foreground prediction for deriving the watershed mask.")
+    parser.add_argument("--distance_smoothing", default=0, type=float,
+                        help="The sigma value for smoothing the distance predictions with a gaussian kernel.")
+
+    args = parser.parse_args()
+
+    gridsearch(
+        val_dir=args.input,
+        model_path=args.model,
+        result_dir=args.output_folder,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prediction/gridsearch_ihc.py
+++ b/scripts/prediction/gridsearch_ihc.py
@@ -1,47 +1,49 @@
-"""Prediction using distance U-Net.
-Parallelization using multiple GPUs is currently only possible
-by calling functions located in segmentation/unet_prediction.py directly.
-Functions for the parallelization end with '_slurm' and divide the process into preprocessing,
-prediction, and segmentation.
-"""
 import argparse
-import json
-import time
-import os
 
-import imageio.v3 as imageio
-import torch
-import z5py
-
-from flamingo_tools.segmentation.gridsearch import gridsearch
+from flamingo_tools.segmentation.gridsearch import gridsearch, DEFAULT_GRID_SEARCH_VALUES
 
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="Find watershed parameters that maximise symmetric best-Dice on a validation set for IHCs. "
+                    "The parameters 'center_distance_threshold', 'boundary_distance_threshold', "
+                    "and 'distance_smoothing' are optimized during the process."
+    )
     parser.add_argument("-i", "--input", required=True)
     parser.add_argument("-o", "--output_folder", required=True)
     parser.add_argument("-m", "--model", required=True)
     parser.add_argument("-b", "--block_shape", default=None, type=str)
     parser.add_argument("--halo", default=None, type=str)
-    parser.add_argument("--seg_class", default=None, type=str,
-                        help="Segmentation class to load parameters for masking input.")
-    parser.add_argument("--center_distance_threshold", default=0.4, type=float,
+    parser.add_argument("--center_distance_threshold", nargs="+", default=None, type=float,
                         help="The threshold applied to the distance center predictions to derive seeds.")
-    parser.add_argument("--boundary_distance_threshold", default=None, type=float,
-                        help="The threshold applied to the boundary predictions to derive seeds. \
-                        By default this is set to 'None', \
-                        in which case the boundary distances are not used for the seeds.")
-    parser.add_argument("--fg_threshold", default=0.5, type=float,
-                        help="The threshold applied to the foreground prediction for deriving the watershed mask.")
+    parser.add_argument("--boundary_distance_threshold", nargs="+", default=None, type=float,
+                        help="The threshold applied to the boundary predictions to derive seeds.")
     parser.add_argument("--distance_smoothing", default=0, type=float,
                         help="The sigma value for smoothing the distance predictions with a gaussian kernel.")
+    parser.add_argument("--fg_threshold", default=0.5, type=float,
+                        help="The threshold applied to the foreground prediction for deriving the watershed mask.")
 
     args = parser.parse_args()
+
+    grid_search_values = DEFAULT_GRID_SEARCH_VALUES
+
+    if args.center_distance_threshold is not None:
+        grid_search_values["center_distance_threshold"] = args.center_distance_threshold
+
+    if args.boundary_distance_threshold is not None:
+        grid_search_values["boundary_distance_threshold"] = args.boundary_distance_threshold
+
+    if args.distance_smoothing is not None:
+        grid_search_values["distance_smoothing"] = args.distance_smoothing
 
     gridsearch(
         val_dir=args.input,
         model_path=args.model,
         result_dir=args.output_folder,
+        grid_search_values=grid_search_values,
+        block_shape=args.block_shape,
+        halo=args.halo,
+        fg_threshold=args.fg_threshold,
     )
 
 

--- a/test/test_segmentation/test_gridsearch.py
+++ b/test/test_segmentation/test_gridsearch.py
@@ -1,0 +1,146 @@
+import json
+import os
+import tempfile
+import unittest
+
+import imageio.v3 as imageio
+import numpy as np
+import torch
+from torch_em.model import UNet3d
+
+
+class TestIHCGridsearch(unittest.TestCase):
+    shape = (32, 64, 64)
+
+    GRID_SEARCH_VALUES = {
+        "center_distance_threshold": [0.4, 0.6],
+        "boundary_distance_threshold": [0.4, 0.6],
+        "distance_smoothing": [0.0, 0.5],
+    }
+
+    def _create_model(self, tmp_dir):
+        model = UNet3d(in_channels=1, out_channels=3, initial_features=4, depth=2)
+        model_path = os.path.join(tmp_dir, "model.pt")
+        torch.save(model, model_path)
+        return model_path
+
+    def _create_val_dir(self, tmp_dir, n_images=2):
+        val_dir = os.path.join(tmp_dir, "val")
+        os.makedirs(val_dir)
+        rng = np.random.default_rng(0)
+        for i in range(n_images):
+            image = rng.integers(0, 255, size=self.shape, dtype=np.uint16)
+            label = rng.integers(0, 3, size=self.shape, dtype=np.uint16)
+            imageio.imwrite(os.path.join(val_dir, f"sample_{i:02d}.tif"), image)
+            imageio.imwrite(os.path.join(val_dir, f"sample_{i:02d}_annotations.tif"), label)
+        return val_dir
+
+    def test_find_image_label_pairs(self):
+        from flamingo_tools.segmentation.gridsearch import _find_image_label_pairs
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            val_dir = self._create_val_dir(tmp_dir, n_images=3)
+            pairs = _find_image_label_pairs(val_dir)
+            self.assertEqual(len(pairs), 3)
+            for image_path, label_path in pairs:
+                self.assertTrue(os.path.exists(image_path))
+                self.assertTrue(os.path.exists(label_path))
+                self.assertFalse(image_path.endswith("_annotations.tif"))
+                self.assertTrue(label_path.endswith("_annotations.tif"))
+
+    def test_gridsearch_returns_best_params(self):
+        from flamingo_tools.segmentation.gridsearch import gridsearch
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            val_dir = self._create_val_dir(tmp_dir)
+            model_path = self._create_model(tmp_dir)
+            best_params, best_score = gridsearch(
+                val_dir, model_path,
+                grid_search_values=self.GRID_SEARCH_VALUES,
+                block_shape=(32, 64, 64), halo=(4, 8, 8),
+            )
+            self.assertIsInstance(best_params, dict)
+            self.assertIn("center_distance_threshold", best_params)
+            self.assertIn("boundary_distance_threshold", best_params)
+            self.assertIn("distance_smoothing", best_params)
+            self.assertIsInstance(best_score, float)
+            self.assertGreaterEqual(best_score, 0.0)
+            self.assertLessEqual(best_score, 1.0)
+
+    def test_gridsearch_writes_per_image_json(self):
+        from flamingo_tools.segmentation.gridsearch import gridsearch
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            val_dir = self._create_val_dir(tmp_dir)
+            model_path = self._create_model(tmp_dir)
+            result_dir = os.path.join(tmp_dir, "results")
+            gridsearch(
+                val_dir, model_path,
+                result_dir=result_dir,
+                grid_search_values=self.GRID_SEARCH_VALUES,
+                block_shape=(32, 64, 64), halo=(4, 8, 8),
+            )
+            json_files = [f for f in os.listdir(result_dir) if f.endswith(".json")]
+            self.assertEqual(len(json_files), 2)
+            for jf in json_files:
+                with open(os.path.join(result_dir, jf)) as fh:
+                    records = json.load(fh)
+                # 2×2×2 combos = 8 records per image
+                self.assertEqual(len(records), 8)
+                for rec in records:
+                    self.assertIn("dice", rec)
+                    self.assertIn("center_distance_threshold", rec)
+
+    def test_gridsearch_resumes_from_cache(self):
+        from flamingo_tools.segmentation.gridsearch import gridsearch
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            val_dir = self._create_val_dir(tmp_dir, n_images=1)
+            model_path = self._create_model(tmp_dir)
+            result_dir = os.path.join(tmp_dir, "results")
+
+            # First run: writes JSON
+            params1, score1 = gridsearch(
+                val_dir, model_path,
+                result_dir=result_dir,
+                grid_search_values=self.GRID_SEARCH_VALUES,
+                block_shape=(32, 64, 64), halo=(4, 8, 8),
+            )
+
+            # Second run: must load from cache (model path is invalid to verify no re-prediction)
+            params2, score2 = gridsearch(
+                val_dir, "nonexistent_model.pt",
+                result_dir=result_dir,
+                grid_search_values=self.GRID_SEARCH_VALUES,
+                block_shape=(32, 64, 64), halo=(4, 8, 8),
+            )
+
+            self.assertEqual(params1, params2)
+            self.assertAlmostEqual(score1, score2, places=6)
+
+    def test_get_or_compute_best_params_caches(self):
+        from flamingo_tools.segmentation.gridsearch import get_or_compute_best_params
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            val_dir = self._create_val_dir(tmp_dir)
+            model_path = self._create_model(tmp_dir)
+            result_dir = os.path.join(tmp_dir, "results")
+
+            params1, score1 = get_or_compute_best_params(
+                model_path, val_dir,
+                result_dir=result_dir,
+                grid_search_values=self.GRID_SEARCH_VALUES,
+                block_shape=(32, 64, 64), halo=(4, 8, 8),
+            )
+
+            cache_path = os.path.splitext(model_path)[0] + "_best_params.json"
+            self.assertTrue(os.path.exists(cache_path))
+
+            params2, score2 = get_or_compute_best_params(
+                model_path, val_dir,
+                result_dir=result_dir,
+                grid_search_values=self.GRID_SEARCH_VALUES,
+                block_shape=(32, 64, 64), halo=(4, 8, 8),
+            )
+
+            self.assertEqual(params1, params2)
+            self.assertAlmostEqual(score1, score2, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Add gridsearch for IHC distance-watershed parameters**

Adds `flamingo_tools/segmentation/gridsearch.py` with a parameter sweep over the three distance-watershed settings (`center_distance_threshold`, `boundary_distance_threshold`, `distance_smoothing`) that control IHC instance segmentation quality.

**Key design decisions**:
- Model prediction is run once per image and held in memory; the watershed is then applied for each parameter combination — avoids redundant GPU passes.
- Results for each image are written to a per-image JSON file, so interrupted runs resume cheaply from cached scores.
- Performance is evaluated with elf.evaluation.dice.symmetric_best_dice_score; the combination with the highest mean score across all validation images is returned.
- get_or_compute_best_params caches the final result next to the model file (<model>_best_params.json) for use in downstream inference scripts.

**Files changed**:
- `flamingo_tools/segmentation/gridsearch.py` — new module with `gridsearch` and `get_or_compute_best_params`
- `flamingo_tools/segmentation/__init__.py` — exports both functions
- `scripts/prediction/gridsearch_ihc.py` — CLI script wrapping `gridsearch` with argparse, allowing custom sweep ranges per parameter
- `test/test_segmentation/test_gridsearch.py` — 5 unit tests covering pair discovery, output format, per-image JSON caching, and resume behaviour