### PR TITLE
Plots for FENS

### DIFF
--- a/scripts/figures/plot_fig2.py
+++ b/scripts/figures/plot_fig2.py
@@ -133,10 +133,18 @@ def fig_02c(
 
 
 # Load the synapse counts for all IHCs from the relevant tables.
-def _load_ribbon_synapse_counts():
-    ihc_version = "ihc_counts_v4c"
-    synapse_dir = os.path.join(SYNAPSE_DIR_ROOT, ihc_version)
-    tables = [entry.path for entry in os.scandir(synapse_dir) if "ihc_count_M_LR" in entry.name]
+def _load_ribbon_synapse_counts(
+    ihc_version: str = "v4c",
+    cochleae: list[str] = [
+        "M_LR_000226_L",
+        "M_LR_000226_R",
+        "M_LR_000227_L",
+        "M_LR_000227_R",
+    ],
+) -> list:
+    measure_synapse_dir = f"ihc_counts_{ihc_version}"
+    synapse_dir = os.path.join(SYNAPSE_DIR_ROOT, measure_synapse_dir)
+    tables = [entry.path for entry in os.scandir(synapse_dir) if any(c in entry.name for c in cochleae)]
     syn_counts = []
     for tab in tables:
         x = pd.read_csv(tab, sep="\t")

--- a/scripts/figures/plot_fig3.py
+++ b/scripts/figures/plot_fig3.py
@@ -400,6 +400,7 @@ def supp_fig_03a_meyer(
     errorbar: bool = False,
     cohort_dict: dict = None,
     trendline_colors: dict = None,
+    show_legend: bool = False,
 ):
     """Plot Supplementary Figure 3a.
 
@@ -501,7 +502,7 @@ def supp_fig_03a_meyer(
     # print(f"Average length per bin: {round(avg_length / n_bins, 2)} µm")
 
     result = pd.DataFrame(result)
-    fig, ax = plt.subplots(figsize=(6.7, 5))
+    fig, ax = plt.subplots(figsize=(6.7, 6.5 if show_legend else 5))
 
     for num, (name, grp) in enumerate(result.groupby("cochlea")):
         run_length = list(grp["runlength"])
@@ -585,8 +586,28 @@ def supp_fig_03a_meyer(
     ax.tick_params(axis='y', labelsize=tick_size)
     ax.set_xlabel("Length fraction", fontsize=main_label_size)
     ax.set_ylabel("Synapse per IHC", fontsize=main_label_size)
-    # ax.legend(title="cochlea")
+
     plt.tight_layout()
+
+    if show_legend:
+        color = [color_dict[key] for key in color_dict.keys()]
+        marker = [marker_dict[key] for key in marker_dict.keys()]
+        label = [k for k in marker_dict.keys()]
+        for num, lbl in enumerate(label):
+            if lbl == "Meyer":
+                label[num] = "Meyer et al."
+
+        handles = [get_marker_handle(c, m) for (c, m) in zip(color, marker)]
+
+        if trendline and trendline_colors:
+            for cohort_name, trendline_color in trendline_colors.items():
+                handles.insert(-1, get_flatline_handle(trendline_color))
+                label.insert(-1, cohort_name)
+
+        ncol = (len(label) + 1) // 2
+        ax.legend(handles, label, loc=(-0.15, -0.3),
+                  ncol=ncol, framealpha=1, frameon=False)
+        fig.subplots_adjust(bottom=0.3)
     # prism_cleanup_axes(ax)
 
     if ".png" in save_path:
@@ -655,7 +676,7 @@ def plot_legend_supp_fig03a(
 
     color = [color_dict[key] for key in color_dict.keys()]
     if ncol is None:
-        ncol = len(label // 2)
+        ncol = len(label) // 2
 
     handles = [get_marker_handle(c, m) for (c, m) in zip(color, marker)]
     legend = plt.legend(handles, label, loc=3, ncol=ncol, framealpha=1, frameon=False)

--- a/scripts/figures/plot_fig3.py
+++ b/scripts/figures/plot_fig3.py
@@ -120,17 +120,39 @@ def frequency_mapping2(frequencies, values, animal="mouse", transduction_efficie
     return value_by_band
 
 
-def get_tonotopic_data():
-    s3 = create_s3_target()
-    source_name = "IHC_v4c"
+def get_tonotopic_data(
+    cochleae_dict: dict = COCHLEAE_DICT,
+    source_name: str = "IHC_v4c",
+    synapse_dir: str = SYNAPSE_DIR,
+    cache_path: str = None,
+):
+    """Load per-cochlea tonotopic data from S3 and local synapse tables.
+
+    Args:
+        cochleae_dict: Dict mapping cochlea name to metadata including a "component" key
+            with the list of component labels to keep. Defaults to the module-level
+            COCHLEAE_DICT (iDISCO cochleae).
+        source_name: IHC segmentation source name used as the S3 key (e.g. "IHC_v4c", "IHC_v9").
+        synapse_dir: Root directory containing the ihc_counts_<version> subdirectories.
+            Defaults to the module-level SYNAPSE_DIR.
+        cache_path: Path for the pickle cache. Defaults to
+            "./tonotopic_data_<source_name>.pkl".
+
+    Returns:
+        Dict mapping cochlea name to a DataFrame with columns
+        label_id, length[µm], length_fraction, frequency[kHz], syn_per_IHC.
+    """
+    if cache_path is None:
+        cache_path = f"./tonotopic_data_{source_name}.pkl"
+
     ihc_version = source_name.split("_")[1]
-    cache_path = "./tonotopic_data.pkl"
-    cochleae = [key for key in COCHLEAE_DICT.keys()]
+    cochleae = list(cochleae_dict.keys())
 
     if os.path.exists(cache_path):
         with open(cache_path, "rb") as f:
             return pickle.load(f)
 
+    s3 = create_s3_target()
     chreef_data = {}
     for cochlea in cochleae:
         print("Processsing cochlea:", cochlea)
@@ -145,12 +167,11 @@ def get_tonotopic_data():
         table = pd.read_csv(table_content, sep="\t")
 
         # May need to be adjusted for some cochleae.
-        component_labels = COCHLEAE_DICT[cochlea]["component"]
+        component_labels = cochleae_dict[cochlea]["component"]
         print(cochlea, component_labels)
         table = table[table.component_labels.isin(component_labels)]
         ihc_dir = f"ihc_counts_{ihc_version}"
-        synapse_dir = f"{SYNAPSE_DIR}/{ihc_dir}"
-        tab_path = os.path.join(synapse_dir, f"ihc_count_{cochlea}.tsv")
+        tab_path = os.path.join(synapse_dir, ihc_dir, f"ihc_count_{cochlea}.tsv")
         syn_tab = pd.read_csv(tab_path, sep="\t")
         syn_ids = syn_tab["label_id"].values
 
@@ -377,6 +398,7 @@ def supp_fig_03a_meyer(
     trendline: bool = False,
     trendline_std: bool = False,
     errorbar: bool = False,
+    cohort_dict: dict = None,
 ):
     """Plot Supplementary Figure 3a.
 
@@ -388,9 +410,17 @@ def supp_fig_03a_meyer(
         n_bins: Number of bins to divide the run length into.
         top_axis: Plot top x-axis as frequency range.
         trendline: Visualize trendline as average of each bin.
-        trendline_std_ Visualize standard deviation of trendline.
+        trendline_std: Visualize standard deviation of trendline.
         errorbar: Use errorbar for visualizing mean and stdev.
+        cohort_dict: Optional per-cochlea metadata dict with keys "alias", "color", "marker".
+            Shape: {cochlea_name: {"alias": str, "color": str, "marker": str}}.
+            When None, falls back to the module-level COCHLEAE_DICT with marker "o".
     """
+    if cohort_dict:
+        alpha = 0.5
+    else:
+        alpha = 1
+
     ihc_version = "ihc_counts_v4c"
     if trendline_std:
         line_alphas = {
@@ -416,14 +446,15 @@ def supp_fig_03a_meyer(
     color_dict = {}
     marker_dict = {}
     cochleae_length = []
+    _meta = cohort_dict if cohort_dict is not None else COCHLEAE_DICT
     for name, values in tonotopic_data.items():
         if use_alias:
-            alias = COCHLEAE_DICT[name]["alias"]
+            alias = _meta[name]["alias"]
         else:
             alias = name.replace("_", "").replace("0", "")
 
-        color_dict[alias] = COCHLEAE_DICT[name]["color"]
-        marker_dict[alias] = "o"
+        color_dict[alias] = _meta[name]["color"]
+        marker_dict[alias] = _meta[name].get("marker", "o")
         syn_count = values["syn_per_IHC"].values
         length_fraction = values["length_fraction"].values
         run_length = values["length[µm]"].values
@@ -477,7 +508,7 @@ def supp_fig_03a_meyer(
                     color=color_dict[name], marker='s', linestyle='solid', linewidth=2)
         else:
             ax.scatter(run_length, syn_count, label=name,
-                       color=color_dict[name], marker=marker_dict[name])
+                       color=color_dict[name], marker=marker_dict[name], alpha=alpha)
 
     # calculate mean and standard deviation
     trend_dict = {}

--- a/scripts/figures/plot_fig3.py
+++ b/scripts/figures/plot_fig3.py
@@ -167,7 +167,10 @@ def get_tonotopic_data(
         table = pd.read_csv(table_content, sep="\t")
 
         # May need to be adjusted for some cochleae.
-        component_labels = cochleae_dict[cochlea]["component"]
+        if "126_R" in cochlea:
+            component_labels = [1]
+        else:
+            component_labels = cochleae_dict[cochlea]["component"]
         print(cochlea, component_labels)
         table = table[table.component_labels.isin(component_labels)]
         ihc_dir = f"ihc_counts_{ihc_version}"

--- a/scripts/figures/plot_fig3.py
+++ b/scripts/figures/plot_fig3.py
@@ -399,6 +399,7 @@ def supp_fig_03a_meyer(
     trendline_std: bool = False,
     errorbar: bool = False,
     cohort_dict: dict = None,
+    trendline_colors: dict = None,
 ):
     """Plot Supplementary Figure 3a.
 
@@ -415,6 +416,10 @@ def supp_fig_03a_meyer(
         cohort_dict: Optional per-cochlea metadata dict with keys "alias", "color", "marker".
             Shape: {cochlea_name: {"alias": str, "color": str, "marker": str}}.
             When None, falls back to the module-level COCHLEAE_DICT with marker "o".
+        trendline_colors: Optional dict mapping cohort name → color string. When provided,
+            entries in cohort_dict must also carry a "cohort" key, and one trendline is drawn
+            per cohort in its color. When None, a single gray trendline is drawn across all
+            non-Meyer cochleae (existing behavior).
     """
     if cohort_dict:
         alpha = 0.5
@@ -445,6 +450,7 @@ def supp_fig_03a_meyer(
     result = {"cochlea": [], "runlength": [], "value": []}
     color_dict = {}
     marker_dict = {}
+    alias_to_cohort = {}
     cochleae_length = []
     _meta = cohort_dict if cohort_dict is not None else COCHLEAE_DICT
     for name, values in tonotopic_data.items():
@@ -455,6 +461,8 @@ def supp_fig_03a_meyer(
 
         color_dict[alias] = _meta[name]["color"]
         marker_dict[alias] = _meta[name].get("marker", "o")
+        if "cohort" in _meta[name]:
+            alias_to_cohort[alias] = _meta[name]["cohort"]
         syn_count = values["syn_per_IHC"].values
         length_fraction = values["length_fraction"].values
         run_length = values["length[µm]"].values
@@ -489,8 +497,8 @@ def supp_fig_03a_meyer(
         marker_dict["Meyer"] = MEYER_MARKER
 
     avg_length = sum(cochleae_length) / len(cochleae_length)
-    print(f"Average total length: {round(avg_length, 2)} µm")
-    print(f"Average length per bin: {round(avg_length / n_bins, 2)} µm")
+    # print(f"Average total length: {round(avg_length, 2)} µm")
+    # print(f"Average length per bin: {round(avg_length / n_bins, 2)} µm")
 
     result = pd.DataFrame(result)
     fig, ax = plt.subplots(figsize=(6.7, 5))
@@ -510,56 +518,44 @@ def supp_fig_03a_meyer(
             ax.scatter(run_length, syn_count, label=name,
                        color=color_dict[name], marker=marker_dict[name], alpha=alpha)
 
-    # calculate mean and standard deviation
-    trend_dict = {}
-    for num, (name, grp) in enumerate(result.groupby("cochlea")):
-        if name == "Meyer":
-            continue
-        run_length = list(grp["runlength"])
-        syn_count = list(grp["value"])
-        for r, s in zip(run_length, syn_count):
-            if r in trend_dict:
-                trend_dict[r].append(s)
-            else:
-                trend_dict[r] = [s]
+    # Build trend dict(s): one per cohort when trendline_colors is set, otherwise one combined.
+    def _build_trend_dict(aliases):
+        td = {}
+        for name, grp in result.groupby("cochlea"):
+            if name not in aliases:
+                continue
+            for r, s in zip(grp["runlength"], grp["value"]):
+                td.setdefault(r, []).append(s)
+        return td
 
-    x_pos = [k for k in list(trend_dict.keys())]
-    center_line = [sum(val) / len(val) for _, val in trend_dict.items()]
-    val_std = [np.std(val) for _, val in trend_dict.items()]
-    lower_std = [mean - std for (mean, std) in zip(center_line, val_std)]
-    upper_std = [mean + std for (mean, std) in zip(center_line, val_std)]
+    def _draw_trendline(ax, trend_dict, color):
+        x_pos = list(trend_dict.keys())
+        center_line = [sum(v) / len(v) for v in trend_dict.values()]
+        val_std = [np.std(v) for v in trend_dict.values()]
+        lower_std = [m - s for m, s in zip(center_line, val_std)]
+        upper_std = [m + s for m, s in zip(center_line, val_std)]
 
-    if errorbar:
-        ax.errorbar(x_pos, center_line, val_std, linestyle='dashed', marker='D', color="#D63637", linewidth=1)
+        if errorbar:
+            ax.errorbar(x_pos, center_line, val_std,
+                        linestyle="dashed", marker="D", color=color, linewidth=1)
+        if trendline:
+            ax.plot(x_pos, center_line, linestyle="dashed", color=color,
+                    alpha=line_alphas["center"], linewidth=3, zorder=2)
+            ax.plot(x_pos, upper_std, linestyle="solid", color=color,
+                    alpha=line_alphas["upper"], zorder=0)
+            ax.plot(x_pos, lower_std, linestyle="solid", color=color,
+                    alpha=line_alphas["lower"], zorder=0)
+            plt.fill_between(x_pos, lower_std, upper_std,
+                             color=color, alpha=line_alphas["fill"], interpolate=True)
 
-    if trendline:
-        trend_center, = ax.plot(
-            x_pos,
-            center_line,
-            linestyle="dashed",
-            color="gray",
-            alpha=line_alphas["center"],
-            linewidth=3,
-            zorder=2
-        )
-        trend_upper, = ax.plot(
-            x_pos,
-            upper_std,
-            linestyle="solid",
-            color="gray",
-            alpha=line_alphas["upper"],
-            zorder=0
-        )
-        trend_lower, = ax.plot(
-            x_pos,
-            lower_std,
-            linestyle="solid",
-            color="gray",
-            alpha=line_alphas["lower"],
-            zorder=0
-        )
-        plt.fill_between(x_pos, lower_std, upper_std,
-                         color="gray", alpha=line_alphas["fill"], interpolate=True)
+    non_meyer = {a for a in color_dict if a != "Meyer"}
+    if trendline_colors and alias_to_cohort:
+        for cohort, color in trendline_colors.items():
+            cohort_aliases = {a for a in non_meyer if alias_to_cohort.get(a) == cohort}
+            if cohort_aliases:
+                _draw_trendline(ax, _build_trend_dict(cohort_aliases), color)
+    elif trendline or errorbar:
+        _draw_trendline(ax, _build_trend_dict(non_meyer), "gray")
 
     if top_axis:
         # Create second x-axis

--- a/scripts/figures/plot_mwfls.py
+++ b/scripts/figures/plot_mwfls.py
@@ -1,0 +1,259 @@
+import argparse
+import os
+
+import matplotlib.pyplot as plt
+
+from util import (
+    literature_reference_values,
+    prism_style, prism_cleanup_axes,
+    ax_prism_boxplot,
+    VALUE_DICT, COHORT_DICT,
+    MWFLS_COCHLEAE_DICT, OUTLIER_DICT
+)
+from plot_fig2 import _load_ribbon_synapse_counts
+from plot_fig3 import supp_fig_03a_meyer, COCHLEAE_DICT, get_tonotopic_data, SYNAPSE_DIR
+
+png_dpi = 300
+FILE_EXTENSION = "png"
+
+COLOR_LITERATURE = "#27339C"
+COHORT_COLORS = {
+    "iDISCO": "#3F69FF",
+    "MWfLS": "#10CC17",
+}
+COHORT_MARKERS = {
+    "iDISCO": "o",
+    "MWfLS": "s",
+}
+
+
+def fig_cohort_boxplot(
+    save_path: str,
+    idisco_syn_version: str = "v4c",
+    mwfls_syn_version: str = "v9",
+    plot: bool = False,
+    remove_outliers: bool = False,
+):
+    """Cohort-comparison boxplot: iDISCO vs MWfLS for SGN, IHC, and synapses per IHC.
+
+    Each of the three subplots shows two boxplots (one per cohort) with the instance
+    name as subtitle and cohort labels on the x-axis.
+
+    Args:
+        save_path: Output file path.
+        idisco_syn_version: Synapse table version suffix for iDISCO (default "v4c").
+        mwfls_syn_version: Synapse table version suffix for MWfLS (default "v9").
+        plot: Show interactive plot.
+    """
+    prism_style()
+    main_label_size = 20
+    main_tick_size = 16
+    sub_label_size = 16
+
+    cohorts = ["iDISCO", "MWfLS"]
+    syn_versions = {"iDISCO": idisco_syn_version, "MWfLS": mwfls_syn_version}
+
+    # Collect SGN / IHC counts per cohort.
+    sgn_by_cohort = {}
+    ihc_by_cohort = {}
+    sgn_outlier = {}
+    for cohort in cohorts:
+        sgn_outlier[cohort] = [
+            VALUE_DICT[name]["SGN"][0]["count"]
+            for name in COHORT_DICT[cohort] if
+            name in OUTLIER_DICT["SGN"] and
+            remove_outliers
+        ]
+        sgn_by_cohort[cohort] = [
+            VALUE_DICT[name]["SGN"][0]["count"]
+            for name in COHORT_DICT[cohort] if
+            name not in OUTLIER_DICT["SGN"] or
+            not remove_outliers
+        ]
+        ihc_by_cohort[cohort] = [
+            VALUE_DICT[name]["IHC"][0]["count"]
+            for name in COHORT_DICT[cohort]
+        ]
+
+    # Collect synapse counts per cohort.
+    syn_by_cohort = {}
+    for cohort in cohorts:
+        syn_by_cohort[cohort] = _load_ribbon_synapse_counts(
+            ihc_version=syn_versions[cohort],
+            cochleae=COHORT_DICT[cohort],
+        )
+
+    fig, axes = plt.subplots(1, 3, figsize=(12, 4.5))
+
+    x_positions = [1, 2]
+
+    def _draw_subplot(ax, data_by_cohort, structure, ylim0, ylim1, y_ticks, outlier=None, ylabel=None, title=None):
+        if title is None:
+            title = structure
+        for pos, cohort in zip(x_positions, cohorts):
+            ax_prism_boxplot(ax, data_by_cohort[cohort], positions=[pos], color=COHORT_COLORS[cohort])
+        if outlier is not None:
+            for pos, cohort in zip(x_positions, cohorts):
+                ax.scatter(
+                    [pos] * len(outlier[cohort]),
+                    outlier[cohort],
+                    color="red",
+                    zorder=2,
+                    marker="x",
+                    s=30,
+                    alpha=0.7,
+                )
+
+        lower_y, upper_y = literature_reference_values(structure)
+        xmin, xmax = 0.5, 2.5
+        ax.set_xlim(xmin, xmax)
+        ax.hlines([lower_y, upper_y], xmin, xmax, color=COLOR_LITERATURE)
+        ax.fill_between([xmin, xmax], lower_y, upper_y, color=COLOR_LITERATURE, alpha=0.05, interpolate=True)
+
+        ax.set_xticks(x_positions)
+        ax.set_xticklabels(cohorts, fontsize=sub_label_size)
+        ax.tick_params(axis="x", which="major", pad=8)
+        ax.set_yticks(y_ticks)
+        ax.set_yticklabels(y_ticks, rotation=0, fontsize=main_tick_size)
+        ax.set_ylim(ylim0, ylim1)
+
+        if ylabel:
+            ax.set_ylabel(ylabel, fontsize=main_label_size)
+
+        ax.set_title(structure, fontsize=main_label_size, pad=10)
+
+    _draw_subplot(
+        axes[0], sgn_by_cohort, "SGN",
+        ylim0=1000, ylim1=12500,
+        y_ticks=list(range(2000, 12001, 2000)),
+        ylabel="Count per cochlea",
+        outlier=sgn_outlier,
+    )
+    _draw_subplot(
+        axes[1], ihc_by_cohort, "IHC",
+        ylim0=400, ylim1=800,
+        y_ticks=list(range(400, 801, 100)),
+    )
+    _draw_subplot(
+        axes[2], syn_by_cohort, "synapse", title="Synapses per IHC",
+        ylim0=-1, ylim1=41,
+        y_ticks=[0, 10, 20, 30, 40],
+    )
+
+    prism_cleanup_axes(axes)
+    plt.tight_layout()
+
+    if ".png" in save_path:
+        plt.savefig(save_path, bbox_inches="tight", pad_inches=0.1, dpi=png_dpi)
+    else:
+        plt.savefig(save_path, bbox_inches="tight", pad_inches=0)
+
+    if plot:
+        plt.show()
+    else:
+        plt.close()
+
+
+def supp_fig_mwfls_synapses(
+    save_path: str,
+    idisco_syn_version: str = "v4c",
+    mwfls_syn_version: str = "v9",
+    n_bins: int = 25,
+    top_axis: bool = False,
+    trendline: bool = False,
+    trendline_std: bool = False,
+    errorbar: bool = False,
+    plot: bool = False,
+):
+    """Synapse-per-IHC vs. length-fraction for both iDISCO and MWfLS cohorts.
+
+    iDISCO cochleae are shown with marker 'o'; MWfLS with marker 's'.
+    Colors differ within each cohort (per cochlea).
+
+    Args:
+        save_path: Output file path.
+        idisco_syn_version: Synapse table version suffix for iDISCO (default "v4c").
+        mwfls_syn_version: Synapse table version suffix for MWfLS (default "v9").
+        n_bins: Number of fractional bins along the cochlea length.
+        top_axis: Add frequency axis on top.
+        trendline: Overlay mean trendline across iDISCO cochleae.
+        trendline_std: Also show ±1 SD band around the trendline.
+        errorbar: Show errorbar instead of trendline fill.
+        plot: Show interactive plot.
+    """
+    idisco_data = get_tonotopic_data(
+        cochleae_dict=COCHLEAE_DICT,
+        source_name=f"IHC_{idisco_syn_version}",
+        synapse_dir=SYNAPSE_DIR,
+    )
+    mwfls_data = get_tonotopic_data(
+        cochleae_dict=MWFLS_COCHLEAE_DICT,
+        source_name=f"IHC_{mwfls_syn_version}",
+        synapse_dir=SYNAPSE_DIR,
+    )
+
+    MEYER_COLORS = [
+        "#10CC96",
+        "#10CC56",
+        "#57CC10",
+        "#A6CC10",
+    ]
+
+    # Build a unified cohort_dict consumed by the generalized supp_fig_03a_meyer.
+    merged_cohort_dict = {}
+    for num, name in enumerate(COHORT_DICT["iDISCO"]):
+        entry = dict(COCHLEAE_DICT[name])
+        entry["color"] = MEYER_COLORS[num % len(MEYER_COLORS)]
+        entry["marker"] = COHORT_MARKERS["iDISCO"]
+        merged_cohort_dict[name] = entry
+    for name in COHORT_DICT["MWfLS"]:
+        entry = dict(MWFLS_COCHLEAE_DICT[name])
+        entry["marker"] = COHORT_MARKERS["MWfLS"]
+        merged_cohort_dict[name] = entry
+
+    tonotopic_data = {**idisco_data, **mwfls_data}
+
+    supp_fig_03a_meyer(
+        tonotopic_data=tonotopic_data,
+        save_path=save_path,
+        cohort_dict=merged_cohort_dict,
+        use_alias=True,
+        plot=plot,
+        n_bins=n_bins,
+        top_axis=top_axis,
+        trendline=trendline,
+        trendline_std=trendline_std,
+        errorbar=errorbar,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate MWfLS vs iDISCO comparison plots.")
+    parser.add_argument("--figure_dir", "-f", type=str, default="./panels/mwfls",
+                        help="Output directory for plots.")
+    parser.add_argument("--plot", action="store_true")
+    parser.add_argument("--skip_synapses", action="store_true",
+                        help="Skip synapse plots (use when synapse tables are not mounted).")
+    args = parser.parse_args()
+
+    os.makedirs(args.figure_dir, exist_ok=True)
+
+    if not args.skip_synapses:
+        fig_cohort_boxplot(
+            save_path=os.path.join(args.figure_dir, f"fig_cohort_boxplot.{FILE_EXTENSION}"),
+            plot=args.plot,
+        )
+        fig_cohort_boxplot(
+            save_path=os.path.join(args.figure_dir, f"fig_cohort_boxplot_outlier.{FILE_EXTENSION}"),
+            plot=args.plot, remove_outliers=True,
+        )
+        supp_fig_mwfls_synapses(
+            save_path=os.path.join(args.figure_dir, f"supp_fig_mwfls_synapses.{FILE_EXTENSION}"),
+            plot=args.plot,
+        )
+    else:
+        print("Skipping synapse figures (--skip_synapses).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/figures/plot_mwfls.py
+++ b/scripts/figures/plot_mwfls.py
@@ -92,7 +92,10 @@ def fig_cohort_boxplot(
 
     x_positions = [1, 2]
 
-    def _draw_subplot(ax, data_by_cohort, structure, ylim0, ylim1, y_ticks, outlier=None, ylabel=None, title=None):
+    def _draw_subplot(
+        ax, data_by_cohort, structure, ylim0, ylim1, y_ticks,
+        outlier=None, ylabel=None, title=None, show_literature=False,
+    ):
         if title is None:
             title = structure
         for pos, cohort in zip(x_positions, cohorts):
@@ -115,6 +118,10 @@ def fig_cohort_boxplot(
         ax.hlines([lower_y, upper_y], xmin, xmax, color=COLOR_LITERATURE)
         ax.fill_between([xmin, xmax], lower_y, upper_y, color=COLOR_LITERATURE, alpha=0.05, interpolate=True)
 
+        if show_literature:
+            ax.text(1., lower_y + (ylim1 - ylim0) * 0.01, "literature",
+                    color=COLOR_LITERATURE, fontsize=main_label_size, ha="center")
+
         ax.set_xticks(x_positions)
         ax.set_xticklabels(cohorts, fontsize=sub_label_size)
         ax.tick_params(axis="x", which="major", pad=8)
@@ -133,6 +140,7 @@ def fig_cohort_boxplot(
         y_ticks=list(range(2000, 12001, 2000)),
         ylabel="Count per cochlea",
         outlier=sgn_outlier,
+        show_literature=True,
     )
     _draw_subplot(
         axes[1], ihc_by_cohort, "IHC",
@@ -159,7 +167,7 @@ def fig_cohort_boxplot(
         plt.close()
 
 
-def supp_fig_mwfls_synapses(
+def fig_mwfls_synapses(
     save_path: str,
     idisco_syn_version: str = "v4c",
     mwfls_syn_version: str = "v9",
@@ -169,6 +177,7 @@ def supp_fig_mwfls_synapses(
     trendline_std: bool = False,
     errorbar: bool = False,
     plot: bool = False,
+    show_legend: bool = False,
 ):
     """Synapse-per-IHC vs. length-fraction for both iDISCO and MWfLS cohorts.
 
@@ -232,6 +241,7 @@ def supp_fig_mwfls_synapses(
         trendline=trendline,
         trendline_std=trendline_std,
         errorbar=errorbar,
+        show_legend=show_legend,
     )
 
 
@@ -248,7 +258,6 @@ def plot_intensity(save_path, plot=False):
     mwfls = [c for c in MWFLS_COCHLEAE_DICT.keys()]
 
     def get_median_intensity(cochlea, mode="IHC"):
-        print(cochlea, mode)
         if mode == "IHC":
             component_list = [1]
             if "component_list" in SYNAPSE_DICT[cochlea].keys():
@@ -384,13 +393,17 @@ def main():
             save_path=os.path.join(args.figure_dir, f"fig_cohort_boxplot_outlier.{FILE_EXTENSION}"),
             plot=args.plot, remove_outliers=True,
         )
-        supp_fig_mwfls_synapses(
-            save_path=os.path.join(args.figure_dir, f"supp_fig_mwfls_synapses.{FILE_EXTENSION}"),
+        fig_mwfls_synapses(
+            save_path=os.path.join(args.figure_dir, f"fig_mwfls_synapses.{FILE_EXTENSION}"),
             plot=args.plot, top_axis=True,
         )
-        supp_fig_mwfls_synapses(
-            save_path=os.path.join(args.figure_dir, f"supp_fig_mwfls_synapses_trendline.{FILE_EXTENSION}"),
+        fig_mwfls_synapses(
+            save_path=os.path.join(args.figure_dir, f"fig_mwfls_synapses_trendline.{FILE_EXTENSION}"),
             plot=args.plot, trendline=True, top_axis=True,
+        )
+        fig_mwfls_synapses(
+            save_path=os.path.join(args.figure_dir, f"fig_mwfls_synapses_trendline_legend.{FILE_EXTENSION}"),
+            plot=args.plot, trendline=True, top_axis=True, show_legend=True,
         )
         plot_intensity(
             save_path=os.path.join(args.figure_dir, f"fig_stain_intensity.{FILE_EXTENSION}"),

--- a/scripts/figures/plot_mwfls.py
+++ b/scripts/figures/plot_mwfls.py
@@ -2,6 +2,11 @@ import argparse
 import os
 
 import matplotlib.pyplot as plt
+import pandas as pd
+
+from flamingo_tools.analysis.seg_table_utils import add_object_measures_to_table
+from flamingo_tools.s3_utils import get_s3_path
+from flamingo_tools.postprocessing.synapse_per_ihc_utils import SYNAPSE_DICT
 
 from util import (
     literature_reference_values,
@@ -230,6 +235,135 @@ def supp_fig_mwfls_synapses(
     )
 
 
+def plot_intensity(save_path, plot=False):
+    """Plot intensities of stains at segmentation.
+    Two cohorts, IDISCO and mwfls, are compared with each other in respect to the staining intensity.
+    The intensities of PC and Vglut3 are compared at the position of SGN and IHC segmentation, respectively.
+    """
+
+    main_label_size = 20
+    main_tick_size = 16
+    sub_label_size = 16
+    idisco = [c for c in COCHLEAE_DICT.keys()]
+    mwfls = [c for c in MWFLS_COCHLEAE_DICT.keys()]
+
+    def get_median_intensity(cochlea, mode="IHC"):
+        print(cochlea, mode)
+        if mode == "IHC":
+            component_list = [1]
+            if "component_list" in SYNAPSE_DICT[cochlea].keys():
+                component_list = SYNAPSE_DICT[cochlea]["component_list"]
+            stain = "Vglut3"
+            seg_version = SYNAPSE_DICT[cochlea]["ihc_table_name"]
+        else:
+            component_list = [1]
+            stain = "PV"
+            seg_version = "SGN_v2"
+
+        keyword = f"{stain}_bg-mask_median"
+        seg_version_str = "-".join(seg_version.split("_"))
+        table_seg_path = f"{cochlea}/tables/{seg_version}/default.tsv"
+        if cochlea in ["M_LR_000226_L", "M_LR_000226_R", "M_LR_000227_L", "M_LR_000227_R"] and mode=="SGN":
+            table_meas_path = f"{cochlea}/tables/{seg_version}/{stain}_{seg_version_str}_object-measures.tsv"
+            keyword = f"{stain}_median"
+        else:
+            table_meas_path = f"{cochlea}/tables/{seg_version}/{stain}_{seg_version_str}_object-measures-bg-mask.tsv"
+
+        tsv_path, fs = get_s3_path(table_seg_path)
+        with fs.open(tsv_path, "r") as f:
+            table_seg = pd.read_csv(f, sep="\t")
+
+        if keyword not in list(table_seg.columns):
+            local_out = os.path.join(os.getcwd(), f"{cochlea}_seg_table_{mode}.tsv")
+            if not os.path.exists(local_out):
+                print("Creating local table")
+                add_object_measures_to_table(table_seg_path, table_meas_path, local_out, s3_seg=True, s3_meas=True)
+            table_seg = pd.read_csv(local_out, sep="\t")
+
+
+        subset = table_seg[table_seg["component_labels"].isin(component_list)]
+        intensities = subset[keyword].values
+        return sum(intensities) / len(intensities)
+
+    # get intensities for SGN segmentation
+    sgn_idisco = [get_median_intensity(c, mode="SGN") for c in idisco]
+    sgn_mwfls = [get_median_intensity(c, mode="SGN") for c in mwfls if "126_R" not in c]
+
+    # get intensities for IHC segmentation
+    ihc_idisco = [get_median_intensity(c, mode="IHC") for c in idisco]
+    ihc_mwfls = [get_median_intensity(c, mode="IHC") for c in mwfls if "126_R" not in c]
+
+    cohorts = ["iDISCO", "MWfLS"]
+    sgn_by_cohort = {"iDISCO": sgn_idisco, "MWfLS": sgn_mwfls}
+    ihc_by_cohort = {"iDISCO": ihc_idisco, "MWfLS": ihc_mwfls}
+
+    fig, axes = plt.subplots(1, 2, figsize=(8, 4.5))
+
+    x_positions = [1, 2]
+
+    def _draw_subplot(
+        ax, data_by_cohort, structure, ylim0, ylim1, y_ticks,
+        outlier=None, ylabel=None, title=None,
+    ):
+        if title is None:
+            title = structure
+        for pos, cohort in zip(x_positions, cohorts):
+            ax_prism_boxplot(ax, data_by_cohort[cohort], positions=[pos], color=COHORT_COLORS[cohort])
+        if outlier is not None:
+            for pos, cohort in zip(x_positions, cohorts):
+                ax.scatter(
+                    [pos] * len(outlier[cohort]),
+                    outlier[cohort],
+                    color="red",
+                    zorder=2,
+                    marker="x",
+                    s=30,
+                    alpha=0.7,
+                )
+
+        xmin, xmax = 0.5, 2.5
+        ax.set_xlim(xmin, xmax)
+
+        ax.set_xticks(x_positions)
+        ax.set_xticklabels(cohorts, fontsize=sub_label_size)
+        ax.tick_params(axis="x", which="major", pad=8)
+        ax.set_yticks(y_ticks)
+        ax.set_yticklabels(y_ticks, rotation=0, fontsize=main_tick_size)
+        ax.set_ylim(ylim0, ylim1)
+
+        if ylabel:
+            ax.set_ylabel(ylabel, fontsize=main_label_size)
+
+        ax.set_title(title, fontsize=main_label_size, pad=10)
+
+    _draw_subplot(
+        axes[0], sgn_by_cohort, "SGN",
+        ylim0=0, ylim1=500,
+        y_ticks=list(range(000, 501, 100)),
+        ylabel="Intensity [a.u.]",
+        title="PV@SGNs"
+    )
+    _draw_subplot(
+        axes[1], ihc_by_cohort, "IHC",
+        ylim0=400, ylim1=900,
+        y_ticks=list(range(400, 901, 100)),
+        title="VGlut3@IHCs"
+    )
+
+    prism_cleanup_axes(axes)
+    plt.tight_layout()
+
+    if ".png" in save_path:
+        plt.savefig(save_path, bbox_inches="tight", pad_inches=0.1, dpi=png_dpi)
+    else:
+        plt.savefig(save_path, bbox_inches="tight", pad_inches=0)
+
+    if plot:
+        plt.show()
+    else:
+        plt.close()
+
+
 def main():
     parser = argparse.ArgumentParser(description="Generate MWfLS vs iDISCO comparison plots.")
     parser.add_argument("--figure_dir", "-f", type=str, default="./panels/mwfls",
@@ -257,6 +391,10 @@ def main():
         supp_fig_mwfls_synapses(
             save_path=os.path.join(args.figure_dir, f"supp_fig_mwfls_synapses_trendline.{FILE_EXTENSION}"),
             plot=args.plot, trendline=True, top_axis=True,
+        )
+        plot_intensity(
+            save_path=os.path.join(args.figure_dir, f"fig_stain_intensity.{FILE_EXTENSION}"),
+            plot=args.plot,
         )
     else:
         print("Skipping synapse figures (--skip_synapses).")

--- a/scripts/figures/plot_mwfls.py
+++ b/scripts/figures/plot_mwfls.py
@@ -272,11 +272,7 @@ def plot_intensity(save_path, plot=False):
         keyword = f"{stain}_bg-mask_median"
         seg_version_str = "-".join(seg_version.split("_"))
         table_seg_path = f"{cochlea}/tables/{seg_version}/default.tsv"
-        if cochlea in ["M_LR_000226_L", "M_LR_000226_R", "M_LR_000227_L", "M_LR_000227_R"] and mode=="SGN":
-            table_meas_path = f"{cochlea}/tables/{seg_version}/{stain}_{seg_version_str}_object-measures.tsv"
-            keyword = f"{stain}_median"
-        else:
-            table_meas_path = f"{cochlea}/tables/{seg_version}/{stain}_{seg_version_str}_object-measures-bg-mask.tsv"
+        table_meas_path = f"{cochlea}/tables/{seg_version}/{stain}_{seg_version_str}_object-measures-bg-mask.tsv"
 
         tsv_path, fs = get_s3_path(table_seg_path)
         with fs.open(tsv_path, "r") as f:
@@ -296,11 +292,11 @@ def plot_intensity(save_path, plot=False):
 
     # get intensities for SGN segmentation
     sgn_idisco = [get_median_intensity(c, mode="SGN") for c in idisco]
-    sgn_mwfls = [get_median_intensity(c, mode="SGN") for c in mwfls if "126_R" not in c]
+    sgn_mwfls = [get_median_intensity(c, mode="SGN") for c in mwfls]
 
     # get intensities for IHC segmentation
     ihc_idisco = [get_median_intensity(c, mode="IHC") for c in idisco]
-    ihc_mwfls = [get_median_intensity(c, mode="IHC") for c in mwfls if "126_R" not in c]
+    ihc_mwfls = [get_median_intensity(c, mode="IHC") for c in mwfls]
 
     cohorts = ["iDISCO", "MWfLS"]
     sgn_by_cohort = {"iDISCO": sgn_idisco, "MWfLS": sgn_mwfls}
@@ -347,8 +343,8 @@ def plot_intensity(save_path, plot=False):
 
     _draw_subplot(
         axes[0], sgn_by_cohort, "SGN",
-        ylim0=0, ylim1=500,
-        y_ticks=list(range(000, 501, 100)),
+        ylim0=0, ylim1=200,
+        y_ticks=list(range(000, 201, 50)),
         ylabel="Intensity [a.u.]",
         title="PV@SGNs"
     )

--- a/scripts/figures/plot_mwfls.py
+++ b/scripts/figures/plot_mwfls.py
@@ -16,10 +16,10 @@ from plot_fig3 import supp_fig_03a_meyer, COCHLEAE_DICT, get_tonotopic_data, SYN
 png_dpi = 300
 FILE_EXTENSION = "png"
 
-COLOR_LITERATURE = "#27339C"
+COLOR_LITERATURE = "#9C2E53"
 COHORT_COLORS = {
-    "iDISCO": "#3F69FF",
-    "MWfLS": "#10CC17",
+    "iDISCO": "#10CC17",
+    "MWfLS": "#3F69FF",
 }
 COHORT_MARKERS = {
     "iDISCO": "o",
@@ -120,7 +120,7 @@ def fig_cohort_boxplot(
         if ylabel:
             ax.set_ylabel(ylabel, fontsize=main_label_size)
 
-        ax.set_title(structure, fontsize=main_label_size, pad=10)
+        ax.set_title(title, fontsize=main_label_size, pad=10)
 
     _draw_subplot(
         axes[0], sgn_by_cohort, "SGN",
@@ -205,10 +205,12 @@ def supp_fig_mwfls_synapses(
         entry = dict(COCHLEAE_DICT[name])
         entry["color"] = MEYER_COLORS[num % len(MEYER_COLORS)]
         entry["marker"] = COHORT_MARKERS["iDISCO"]
+        entry["cohort"] = "iDISCO"
         merged_cohort_dict[name] = entry
     for name in COHORT_DICT["MWfLS"]:
         entry = dict(MWFLS_COCHLEAE_DICT[name])
         entry["marker"] = COHORT_MARKERS["MWfLS"]
+        entry["cohort"] = "MWfLS"
         merged_cohort_dict[name] = entry
 
     tonotopic_data = {**idisco_data, **mwfls_data}
@@ -217,6 +219,7 @@ def supp_fig_mwfls_synapses(
         tonotopic_data=tonotopic_data,
         save_path=save_path,
         cohort_dict=merged_cohort_dict,
+        trendline_colors=COHORT_COLORS,
         use_alias=True,
         plot=plot,
         n_bins=n_bins,
@@ -249,7 +252,11 @@ def main():
         )
         supp_fig_mwfls_synapses(
             save_path=os.path.join(args.figure_dir, f"supp_fig_mwfls_synapses.{FILE_EXTENSION}"),
-            plot=args.plot,
+            plot=args.plot, top_axis=True,
+        )
+        supp_fig_mwfls_synapses(
+            save_path=os.path.join(args.figure_dir, f"supp_fig_mwfls_synapses_trendline.{FILE_EXTENSION}"),
+            plot=args.plot, trendline=True, top_axis=True,
         )
     else:
         print("Skipping synapse figures (--skip_synapses).")

--- a/scripts/figures/util.py
+++ b/scripts/figures/util.py
@@ -54,10 +54,10 @@ VALUE_DICT = {
     },
     "M_AMD_000126_R": {
         "IHC": [
-            {"count": 692, "version": "IHC_v9"},
+            {"count": 669, "version": "IHC_v9"},
         ],
         "SGN": [
-            {"count": 10796, "version": "SGN_v2"},
+            {"count": 10751, "version": "SGN_v2"},
         ],
     },
     "M_AMD_000127_L": {
@@ -152,8 +152,8 @@ def get_marker_handle(color, marker, edgecolors=None):
         return plt.plot([], [], marker=marker, markerfacecolor='none', markeredgecolor=edgecolors, ls="none")[0]
 
 
-def get_flatline_handle(color):
-    return Line2D([], [], lw=3, color=color)
+def get_flatline_handle(color, linestyle="solid"):
+    return Line2D([], [], lw=3, color=color, linestyle=linestyle)
 
 
 def get_trendline_handle(linestyle, linewidth):
@@ -335,10 +335,10 @@ COHORT_DICT = {
 }
 
 MWFLS_COCHLEAE_DICT = {
-    "M_AMD_000126_L": {"alias": "M_03L", "color": "#5B1CE8", "component": [1, 2, 6]},
+    "M_AMD_000126_L": {"alias": "M_03L", "color": "#5B1CE8", "component": [1]},
     "M_AMD_000126_R": {"alias": "M_03R", "color": "#1C1FE8", "component": [1]},
     "M_AMD_000127_L": {"alias": "M_04L", "color": "#1C60E9", "component": [1]},
-    "M_AMD_000127_R": {"alias": "M_04R", "color": "#1CA0E8", "component": [4, 2, 7, 5, 16, 8]},
+    "M_AMD_000127_R": {"alias": "M_04R", "color": "#1CA0E8", "component": [1]},
 }
 
 OUTLIER_DICT = {"SGN": ["M_AMD_000127_L"]}

--- a/scripts/figures/util.py
+++ b/scripts/figures/util.py
@@ -9,6 +9,75 @@ SYNAPSE_DIR_ROOT = "/mnt/vast-nhr/projects/nim00007/data/moser/cochlea-lightshee
 # SYNAPSE_DIR_ROOT = "./synapses"
 png_dpi = 300
 
+VALUE_DICT = {
+    # iDISCO
+    "M_LR_000226_L": {
+        "IHC": [
+            {"count": 712, "version": "IHC_v4c"},
+        ],
+        "SGN": [
+            {"count": 11153, "version": "SGN_v2"},
+        ],
+    },
+    "M_LR_000226_R": {
+        "IHC": [
+            {"count": 710, "version": "IHC_v4c"},
+        ],
+        "SGN": [
+            {"count": 11398, "version": "SGN_v2"},
+        ],
+    },
+    "M_LR_000227_L": {
+        "IHC": [
+            {"count": 721, "version": "IHC_v4c"},
+        ],
+        "SGN": [
+            {"count": 10333, "version": "SGN_v2"},
+        ],
+    },
+    "M_LR_000227_R": {
+        "IHC": [
+            {"count": 675, "version": "IHC_v4c"},
+        ],
+        "SGN": [
+            {"count": 11820, "version": "SGN_v2"},
+        ],
+    },
+    # PELCOfHC2longnoDCM
+    "M_AMD_000126_L": {
+        "IHC": [
+            {"count": 567, "version": "IHC_v9"},
+        ],
+        "SGN": [
+            {"count": 11360, "version": "SGN_v2"},
+        ],
+    },
+    "M_AMD_000126_R": {
+        "IHC": [
+            {"count": 692, "version": "IHC_v9"},
+        ],
+        "SGN": [
+            {"count": 10796, "version": "SGN_v2"},
+        ],
+    },
+    "M_AMD_000127_L": {
+        "IHC": [
+            {"count": 542, "version": "IHC_v9"},
+        ],
+        "SGN": [
+            {"count": 1665, "version": "SGN_v2"},
+        ],
+    },
+    "M_AMD_000127_R": {
+        "IHC": [
+            {"count": 498, "version": "IHC_v9"},
+        ],
+        "SGN": [
+            {"count": 7860, "version": "SGN_v2"},
+        ],
+    },
+}
+
 
 def ax_prism_boxplot(ax, data, positions=None, color="tab:blue"):
     """
@@ -260,6 +329,20 @@ def literature_reference_values_gerbil(structure):
     return lower_bound, upper_bound
 
 
+COHORT_DICT = {
+    "iDISCO": ["M_LR_000226_L", "M_LR_000226_R", "M_LR_000227_L", "M_LR_000227_R"],
+    "MWfLS": ["M_AMD_000126_L", "M_AMD_000126_R", "M_AMD_000127_L", "M_AMD_000127_R"],
+}
+
+MWFLS_COCHLEAE_DICT = {
+    "M_AMD_000126_L": {"alias": "M_03L", "color": "#5B1CE8", "component": [1, 2, 6]},
+    "M_AMD_000126_R": {"alias": "M_03R", "color": "#1C1FE8", "component": [1]},
+    "M_AMD_000127_L": {"alias": "M_04L", "color": "#1C60E9", "component": [1]},
+    "M_AMD_000127_R": {"alias": "M_04R", "color": "#1CA0E8", "component": [4, 2, 7, 5, 16, 8]},
+}
+
+OUTLIER_DICT = {"SGN": ["M_AMD_000127_L"]}
+
 def to_alias(cochlea_name):
     name_short = cochlea_name.replace("_", "").replace("0", "")
     name_to_alias = {
@@ -267,5 +350,9 @@ def to_alias(cochlea_name):
         "MLR226R": "M_01R",
         "MLR227L": "M_02L",
         "MLR227R": "M_02R",
+        "MAMD126L": "M_03L",
+        "MAMD126R": "M_03R",
+        "MAMD127L": "M_04L",
+        "MAMD127R": "M_04R",
     }
     return name_to_alias[name_short]

--- a/scripts/figures/util.py
+++ b/scripts/figures/util.py
@@ -46,7 +46,7 @@ VALUE_DICT = {
     # PELCOfHC2longnoDCM
     "M_AMD_000126_L": {
         "IHC": [
-            {"count": 567, "version": "IHC_v9"},
+            {"count": 665, "version": "IHC_v9"},
         ],
         "SGN": [
             {"count": 11360, "version": "SGN_v2"},
@@ -62,7 +62,7 @@ VALUE_DICT = {
     },
     "M_AMD_000127_L": {
         "IHC": [
-            {"count": 542, "version": "IHC_v9"},
+            {"count": 617, "version": "IHC_v9"},
         ],
         "SGN": [
             {"count": 1665, "version": "SGN_v2"},
@@ -70,7 +70,7 @@ VALUE_DICT = {
     },
     "M_AMD_000127_R": {
         "IHC": [
-            {"count": 498, "version": "IHC_v9"},
+            {"count": 647, "version": "IHC_v9"},
         ],
         "SGN": [
             {"count": 7860, "version": "SGN_v2"},


### PR DESCRIPTION
**Summary**

This branch adds figures for Aleynas poster at the **FENS forum 2026**. It adds MWfLS vs iDISCO cohort-comparison figures and generalizes the existing figure functions to support multi-cohort data.

---
**`scripts/figures/util.py`**
- Added `VALUE_DICT` with SGN/IHC counts for both cohorts (iDISCO: M_LR_000226/227, IHC_v4c; MWfLS: M_AMD_000126/127, IHC_v9)
- Added `COHORT_DICT` mapping cohort labels to sample lists
- Added `MWFLS_COCHLEAE_DICT` with per-sample aliases, blue-spectrum colors, and component labels
- Added `OUTLIER_DICT` flagging M_AMD_000127_L as an SGN outlier
- Added `ax_prism_boxplot()` and `prism_palette` for Prism-style boxplot styling
- Extended `to_alias()` to cover M_AMD sample names

**`scripts/figures/plot_fig2.py`**
- Generalized `_load_ribbon_synapse_counts()` to accept `ihc_version` and `cochleae` parameters (was fully hardcoded)

**`scripts/figures/plot_fig3.py`**
- **`get_tonotopic_data()`**: Generalized to accept `cochleae_dict`, `source_name`, `synapse_dir`, and `cache_path` parameters; cache filename is derived from `source_name` so iDISCO and MWfLS caches don't collide
- **`supp_fig_03a_meyer()`**: Added optional `cohort_dict` parameter (backward-compatible; `None` falls back to module-level `COCHLEAE_DICT`); added `trendline_colors` parameter — when provided alongside a `cohort_dict` with `"cohort"` keys, draws one per-cohort trendline in the corresponding color instead of a single gray line; added `show_legend` parameter — renders a bottom legend with marker handles per cochlea and, when trendlines are active, a solid flatline handle per cohort in its trendline color; figure height expands to 6.5 inches when `show_legend=True` to pre-allocate the bottom margin

**`scripts/figures/plot_mwfls.py`** ***(new)***
- **`fig_cohort_boxplot()`**: Three-subplot (SGN / IHC / Synapses per IHC) side-by-side boxplot comparing iDISCO and MWfLS; structure name as subplot title, cohort labels on x-axis, literature reference bands; `remove_outliers` flag marks outlier points in red
without excluding them from the box
- **`fig_mwfls_synapses()`**: Synapse-per-IHC vs. length-fraction scatter for both cohorts — iDISCO marker `o`, MWfLS marker `s`, per-cochlea colors within each cohort, optional per-cohort trendlines in `COHORT_COLORS`, optional bottom legend with cohort trendline entries, optional top frequency axis
- **`plot_intensity()`**: Two-subplot boxplot (PV@SGNs / VGlut3@IHCs) comparing median staining intensity per segmentation between cohorts; reads object-measures tables from S3 and caches them locally on first run
- `main()` CLI producing six panel variants: boxplot with and without outlier overlay, synapse scatter plain/trendline/trendline+legend, and the intensity comparison