### PR TITLE
Export specific crops at lower resolution

### DIFF
--- a/flamingo_tools/export_data_utils.py
+++ b/flamingo_tools/export_data_utils.py
@@ -1,0 +1,71 @@
+"""@private
+"""
+
+from typing import List, Tuple
+
+import numpy as np
+
+
+def compute_crop_bb(
+    crop_center: List[float],
+    roi_halo: List[int],
+    voxel_size: float,
+    scale: int,
+    shape: Tuple[int, ...],
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Compute bounding box start/stop for a crop in ZYX pixel coordinates.
+
+    Args:
+        crop_center: Crop center position as [x, y, z] in µm.
+        roi_halo: Halo around the center as [halo_x, halo_y, halo_z] in pixels at the target scale.
+        voxel_size: Isotropic voxel size in µm at full resolution (scale 0).
+        scale: Scale level (0 = full resolution, each step doubles the effective voxel size).
+        shape: Array shape in ZYX order at the target scale.
+
+    Returns:
+        start: ZYX start pixel coordinates, clamped to zero.
+        stop: ZYX stop pixel coordinates, clamped to shape.
+    """
+    center_zyx = np.round(np.array(crop_center[::-1]) / (voxel_size * 2 ** scale)).astype(int)
+    halo_zyx = np.array(roi_halo[::-1])
+    start = np.maximum(0, center_zyx - halo_zyx)
+    stop = np.minimum(np.array(shape), center_zyx + halo_zyx)
+    return start, stop
+
+
+def crop_filter_volume(
+    filter_volume: np.ndarray,
+    start: np.ndarray,
+    stop: np.ndarray,
+    us_factor: int,
+) -> np.ndarray:
+    """Extract and upscale the sub-region of a downsampled cochlea filter volume for a crop.
+
+    Instead of upscaling the entire filter volume to full resolution and then slicing, this
+    function only upscales the small portion covering the requested crop, which is far more
+    memory-efficient when exporting high-resolution crops.
+
+    Args:
+        filter_volume: Downsampled boolean cochlea mask in ZYX order.
+        start: Crop start in scale-s pixel coordinates, ZYX.
+        stop: Crop stop in scale-s pixel coordinates, ZYX.
+        us_factor: Upscale factor to go from filter_volume resolution to scale-s resolution
+            (i.e. ds_factor // 2**scale).
+
+    Returns:
+        Boolean mask aligned to the crop region, shape == stop - start.
+    """
+    # Sub-region of filter_volume covering the crop (1-cell margin for safety).
+    start_fv = np.maximum(0, start // us_factor - 1)
+    stop_fv = np.minimum(np.array(filter_volume.shape), (stop - 1) // us_factor + 2)
+    sub = filter_volume[start_fv[0]:stop_fv[0], start_fv[1]:stop_fv[1], start_fv[2]:stop_fv[2]]
+
+    # Upscale only the sub-region.
+    big = np.repeat(np.repeat(np.repeat(sub, us_factor, 0), us_factor, 1), us_factor, 2)
+
+    # Align to exact crop coordinates.
+    offset = start - start_fv * us_factor
+    crop_size = stop - start
+    return big[offset[0]:offset[0] + crop_size[0],
+               offset[1]:offset[1] + crop_size[1],
+               offset[2]:offset[2] + crop_size[2]]

--- a/scripts/export_data/export_frequency_mapping.py
+++ b/scripts/export_data/export_frequency_mapping.py
@@ -9,11 +9,13 @@ import tifffile
 import zarr
 from matplotlib import cm, colors
 
+from flamingo_tools.export_data_utils import compute_crop_bb
 from flamingo_tools.s3_utils import BUCKET_NAME, SERVICE_ENDPOINT, create_s3_target, get_s3_path
 # from tqdm import tqdm
 
 
-def export_frequency_mapping(cochlea, scale, output_folder, source_name, colormap=None):
+def export_frequency_mapping(cochlea, scale, output_folder, source_name, colormap=None,
+                             crop_center=None, roi_halo=None):
     s3 = create_s3_target()
 
     content = s3.open(f"{BUCKET_NAME}/{cochlea}/dataset.json", mode="r", encoding="utf-8")
@@ -37,7 +39,11 @@ def export_frequency_mapping(cochlea, scale, output_folder, source_name, colorma
     s3_store, _ = get_s3_path(seg_path, bucket_name=BUCKET_NAME, service_endpoint=SERVICE_ENDPOINT)
     input_key = f"s{scale}"
     f = zarr.open(s3_store, mode="r")
-    seg = f[input_key][:]
+    if crop_center is not None:
+        start, stop = compute_crop_bb(crop_center, roi_halo, voxel_size=0.38, scale=scale, shape=f[input_key].shape)
+        seg = f[input_key][start[0]:stop[0], start[1]:stop[1], start[2]:stop[2]]
+    else:
+        seg = f[input_key][:]
 
     mapping = {int(seg_id): freq for seg_id, freq in zip(table.label_id, frequencies)}
     lut = np.zeros(max_id + 1, dtype="float32")
@@ -86,9 +92,16 @@ def main():
     parser.add_argument("--output_folder", "-o", required=True)
     parser.add_argument("--source_name", "-n", required=True)
     parser.add_argument("--colormap")
+    parser.add_argument("--crop_center", nargs=3, type=float, default=None,
+                        help="Crop center as x y z in µm. Requires --roi_halo.")
+    parser.add_argument("--roi_halo", nargs=3, type=int, default=None,
+                        help="Halo around the crop center as halo_x halo_y halo_z in pixels at the target scale.")
     args = parser.parse_args()
 
-    export_frequency_mapping(args.cochlea, args.scale, args.output_folder, args.source_name, args.colormap)
+    export_frequency_mapping(
+        args.cochlea, args.scale, args.output_folder, args.source_name, args.colormap,
+        crop_center=args.crop_center, roi_halo=args.roi_halo,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/export_data/export_lower_resolution.py
+++ b/scripts/export_data/export_lower_resolution.py
@@ -9,6 +9,7 @@ import tifffile
 import zarr
 from elf.parallel import isin
 
+from flamingo_tools.export_data_utils import compute_crop_bb, crop_filter_volume
 from flamingo_tools.s3_utils import get_s3_path, BUCKET_NAME, SERVICE_ENDPOINT
 from flamingo_tools.postprocessing.label_components import filter_cochlea_volume, filter_cochlea_volume_single
 # from skimage.segmentation import relabel_sequential
@@ -127,6 +128,8 @@ def upscale_volume(
 
 
 def export_lower_resolution(args):
+    crop = args.crop_center is not None
+
     # calculate single filter mask for all lower resolutions
     if args.filter_cochlea_channels is not None:
         ds_factor = 48
@@ -155,15 +158,24 @@ def export_lower_resolution(args):
             internal_path = os.path.join(args.cochlea, "images", "ome-zarr", f"{channel}.ome.zarr")
             s3_store, fs = get_s3_path(internal_path, bucket_name=BUCKET_NAME, service_endpoint=SERVICE_ENDPOINT)
             with zarr.open(s3_store, mode="r") as f:
-                data = f[input_key][:].astype("float32")
+                if crop:
+                    start, stop = compute_crop_bb(
+                        args.crop_center, args.roi_halo, voxel_size=0.38, scale=scale, shape=f[input_key].shape
+                    )
+                    data = f[input_key][start[0]:stop[0], start[1]:stop[1], start[2]:stop[2]].astype("float32")
+                else:
+                    data = f[input_key][:].astype("float32")
             print("Data shape", data.shape)
             if args.filter_by_components is not None:
                 print(f"Filtering channel {channel} by components {args.filter_by_components}.")
                 data = filter_component(fs, data, args.cochlea, channel, args.filter_by_components)
             if args.filter_cochlea_channels is not None:
                 us_factor = ds_factor // (2 ** scale)
-                upscaled_filter = upscale_volume(data, filter_volume, upscale_factor=us_factor)
-                data[upscaled_filter == 0] = 0
+                if crop:
+                    applied_filter = crop_filter_volume(filter_volume, start, stop, us_factor)
+                else:
+                    applied_filter = upscale_volume(data, filter_volume, upscale_factor=us_factor)
+                data[applied_filter == 0] = 0
                 if "PV" in channel:
                     max_intensity = 1400
                     data[data > max_intensity] = 0
@@ -196,6 +208,10 @@ def main():
     parser.add_argument("--filter_cochlea_channels", nargs="+", type=str, default=None)
     parser.add_argument("--filter_dilation_iterations", type=int, default=8)
     parser.add_argument("--ome_zarr", action="store_true")
+    parser.add_argument("--crop_center", nargs=3, type=float, default=None,
+                        help="Crop center as x y z in µm. Requires --roi_halo.")
+    parser.add_argument("--roi_halo", nargs=3, type=int, default=None,
+                        help="Halo around the crop center as halo_x halo_y halo_z in pixels at the target scale.")
     args = parser.parse_args()
 
     export_lower_resolution(args)

--- a/scripts/export_data/export_lower_resolution_subtypes.py
+++ b/scripts/export_data/export_lower_resolution_subtypes.py
@@ -6,6 +6,7 @@ import pandas as pd
 import tifffile
 import zarr
 
+from flamingo_tools.export_data_utils import compute_crop_bb
 from flamingo_tools.s3_utils import get_s3_path, BUCKET_NAME, SERVICE_ENDPOINT
 from flamingo_tools.postprocessing.sgn_subtype_utils import STAIN_TO_TYPE, COCHLEAE
 # from skimage.segmentation import relabel_sequential
@@ -135,6 +136,7 @@ def export_lower_resolution(args):
     cochlea = args.cochlea
     subtype_stains = args.stains
     force_overwrite = args.force
+    crop = args.crop_center is not None
     # iterate through exporting lower resolutions
     for scale in args.scale:
         output_folder = os.path.join(args.output_folder, cochlea, f"scale{scale}")
@@ -169,7 +171,13 @@ def export_lower_resolution(args):
             internal_path = os.path.join(cochlea, "images", "ome-zarr", f"{seg_name}.ome.zarr")
             s3_store, fs = get_s3_path(internal_path, bucket_name=BUCKET_NAME, service_endpoint=SERVICE_ENDPOINT)
             with zarr.open(s3_store, mode="r") as f:
-                data = f[input_key][:]
+                if crop:
+                    start, stop = compute_crop_bb(
+                        args.crop_center, args.roi_halo, voxel_size=0.38, scale=scale, shape=f[input_key].shape
+                    )
+                    data = f[input_key][start[0]:stop[0], start[1]:stop[1], start[2]:stop[2]]
+                else:
+                    data = f[input_key][:]
 
             print("Data shape", data.shape)
 
@@ -185,6 +193,10 @@ def main():
     parser.add_argument("-o", "--output_folder", required=True)
     parser.add_argument("--stains", nargs="+", type=str, default=None)
     parser.add_argument("-f", "--force", action="store_true")
+    parser.add_argument("--crop_center", nargs=3, type=float, default=None,
+                        help="Crop center as x y z in µm. Requires --roi_halo.")
+    parser.add_argument("--roi_halo", nargs=3, type=int, default=None,
+                        help="Halo around the crop center as halo_x halo_y halo_z in pixels at the target scale.")
     args = parser.parse_args()
 
     export_lower_resolution(args)

--- a/scripts/export_data/export_synapse_detections.py
+++ b/scripts/export_data/export_synapse_detections.py
@@ -8,6 +8,7 @@ import pandas as pd
 import tifffile
 import zarr
 
+from flamingo_tools.export_data_utils import compute_crop_bb
 from flamingo_tools.s3_utils import BUCKET_NAME, SERVICE_ENDPOINT, create_s3_target, get_s3_path
 from skimage.morphology import ball
 from tqdm import tqdm
@@ -23,12 +24,12 @@ def export_synapse_detections(
     radius: float,
     id_offset: int,
     filter_ihc_components: List[int],
-    position: str,
-    halo: List[int],
+    crop_center: List[float],
+    roi_halo: List[int],
     as_float: bool = False,
     use_syn_ids: bool = False,
 ):
-    """Export synapse detections from S3..
+    """Export synapse detections from S3.
 
     Args:
         cochlea: Cochlea name on S3 bucket.
@@ -40,8 +41,8 @@ def export_synapse_detections(
         radius: The radius for writing the synapse points to the output volume.
         id_offset: Offset of label id of synapse output to have different colours for visualization.
         filter_ihc_components: Component label(s) for filtering IHC segmentation.
-        position: Optional position for extracting a crop from the data. Requires to also pass halo.
-        halo: Halo for extracting a crop from the data.
+        crop_center: Optional crop center as [x, y, z] in µm. Requires roi_halo.
+        roi_halo: Halo around the crop center as [halo_x, halo_y, halo_z] in pixels at the target scale.
         as_float: Whether to save the exported data as floating point values.
         use_syn_ids: Whether to write the synapse IDs or the matched IHC IDs to the output volume.
     """
@@ -89,13 +90,9 @@ def export_synapse_detections(
         ihc_ids = syn_table["matched_ihc"].values
         syn_ids = syn_table["spot_id"].values
 
-        if position is not None:
-            assert halo is not None
-            center = json.loads(position)
-            assert len(halo) == len(center)
-            center = [int(ce / (voxel_size * (2 ** scale))) for ce in center[::-1]]
-            start = np.array([max(0, ce - ha) for ce, ha in zip(center, halo)])[None]
-            stop = np.array([min(sh, ce + ha) for ce, ha, sh in zip(center, halo, shape)])[None]
+        if crop_center is not None:
+            assert roi_halo is not None
+            start, stop = compute_crop_bb(crop_center, roi_halo, voxel_size=voxel_size, scale=scale, shape=shape)
 
             mask = ((coordinates >= start) & (coordinates < stop)).all(axis=1)
             coordinates = coordinates[mask]
@@ -104,7 +101,7 @@ def export_synapse_detections(
             ihc_ids = ihc_ids[mask]
             syn_ids = syn_ids[mask]
 
-            shape = tuple(int(sto - sta) for sta, sto in zip(start.squeeze(), stop.squeeze()))
+            shape = tuple(int(sto - sta) for sta, sto in zip(start, stop))
 
         # Create the output.
         output = np.zeros(shape, dtype="uint16")
@@ -148,8 +145,10 @@ def main():
     parser.add_argument("--radius", type=int, default=3)
     parser.add_argument("--id_offset", type=int, default=0)
     parser.add_argument("--filter_ihc_components", nargs="+", type=int, default=[1])
-    parser.add_argument("--position", default=None)
-    parser.add_argument("--halo", default=None, nargs="+", type=int)
+    parser.add_argument("--crop_center", nargs=3, type=float, default=None,
+                        help="Crop center as x y z in µm. Requires --roi_halo.")
+    parser.add_argument("--roi_halo", nargs=3, type=int, default=None,
+                        help="Halo around the crop center as halo_x halo_y halo_z in pixels at the target scale.")
     parser.add_argument("--as_float", action="store_true")
     parser.add_argument("--use_syn_ids", action="store_true")
     args = parser.parse_args()
@@ -159,7 +158,7 @@ def main():
         args.synapse_name, args.reference_ihcs,
         args.max_dist, args.radius,
         args.id_offset, args.filter_ihc_components,
-        position=args.position, halo=args.halo,
+        crop_center=args.crop_center, roi_halo=args.roi_halo,
         as_float=args.as_float, use_syn_ids=args.use_syn_ids,
     )
 


### PR DESCRIPTION
## Export specific crops with `export_lower_resolution` functionality

**New file:** **`flamingo_tools/export_data_utils.py`**
- `compute_crop_bb(crop_center, roi_halo, voxel_size, scale, shape)` — converts XYZ µm center + XYZ pixel halo → clamped ZYX `start`/`stop` arrays, consistent with `extract_block_single`'s convention
- `crop_filter_volume(filter_volume, start, stop, us_factor)` — extracts only the relevant sub-region of the downsampled cochlea mask, upscales it, and aligns it to the crop; avoids upscaling the full volume

All four scripts now accept `--crop_center x y z` (µm) and `--roi_halo hx hy hz` (pixels at target scale):
- `export_lower_resolution.py`: crops at zarr load time; uses `crop_filter_volume` instead of `upscale_volume` when a crop is active
- `export_lower_resolution_subtypes.py`: crops at zarr load time, then applies subtype filtering on the crop
- `export_frequency_mapping.py`: crops the segmentation before LUT application (saves materialising the full float32/RGBA output)
- `export_synapse_detections.py`: replaces the old `--position`/`--halo` with the same interface; refactors the inline coordinate math to use `compute_crop_bb`

When no crop args are passed, all code paths are identical to before.
Exported data files have the suffix `_crop_<x-coord>-<y-coord-<z-coord>`, same as for `flamingo_tools.extract_block`.